### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Lite mode includes: project, scene, node, script, editor, input, runtime, and in
 
 Open your Godot project with the plugin enabled, then use Claude Code to interact with the editor.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/youichi-uda-godot-mcp-pro).
+
 ## All 162 Tools
 
 ### Project Tools (7)


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/youichi-uda-godot-mcp-pro).