### PR TITLE
Preserve pre-existing MCP autoloads during shutdown

### DIFF
--- a/addons/godot_mcp/plugin.gd
+++ b/addons/godot_mcp/plugin.gd
@@ -18,6 +18,7 @@ var websocket_server: Node
 var command_router: Node
 var status_panel: Control
 var auto_dismiss_dialogs: bool = false
+var _session_added_autoloads: PackedStringArray = PackedStringArray()
 
 func _enter_tree() -> void:
 	# Create command router
@@ -71,26 +72,31 @@ func _exit_tree() -> void:
 
 
 func _inject_autoloads() -> void:
+	_session_added_autoloads = PackedStringArray()
 	var changed := false
 	for entry: Array in _MCP_AUTOLOADS:
 		var key: String = entry[0]
 		var script: String = entry[1]
 		if not ProjectSettings.has_setting(key):
 			ProjectSettings.set_setting(key, "*" + script)
+			_session_added_autoloads.append(key)
 			changed = true
 	if changed:
 		ProjectSettings.save()
 
 
 func _remove_autoloads() -> void:
+	if _session_added_autoloads.is_empty():
+		return
+
 	var changed := false
-	for entry: Array in _MCP_AUTOLOADS:
-		var key: String = entry[0]
+	for key: String in _session_added_autoloads:
 		if ProjectSettings.has_setting(key):
 			ProjectSettings.set_setting(key, null)
 			changed = true
 	if changed:
 		ProjectSettings.save()
+	_session_added_autoloads = PackedStringArray()
 
 
 var _dialog_check_timer: float = 0.0


### PR DESCRIPTION
## Summary

- preserve MCP autoloads that already existed before plugin startup
- only remove autoloads injected by the current plugin session during shutdown

Fixes #17.

## Problem

`_inject_autoloads()` only adds missing managed autoloads, but `_remove_autoloads()` removes all managed autoload keys unconditionally if they exist.

That means projects that already define one or more of these autoloads:

- `MCPScreenshot`
- `MCPInputService`
- `MCPGameInspector`

lose those entries from `project.godot` after `Godot --headless --path . --import` or any shutdown path that triggers `_exit_tree()`.

## Validation

- reproduced on `v1.10.2` with a minimal empty Godot project that pre-defines the 3 MCP autoloads
- before this patch, `--import` removed those pre-existing entries from `project.godot`
- after this patch, the same repro preserves the pre-existing autoloads
- a control case without pre-existing MCP autoloads still exits without leaving those entries behind
