### PR TITLE
Fix synthetic drag-and-drop tests: honor explicit unhandled:false

### DIFF
--- a/addons/godot_mcp/commands/input_commands.gd
+++ b/addons/godot_mcp/commands/input_commands.gd
@@ -79,6 +79,7 @@ func _simulate_mouse_move(params: Dictionary) -> Dictionary:
 	var rel_x: float = float(params.get("relative_x", 0))
 	var rel_y: float = float(params.get("relative_y", 0))
 	var button_mask: int = optional_int(params, "button_mask", 0)
+	var unhandled_explicit: bool = params.has("unhandled")
 	var unhandled: bool = optional_bool(params, "unhandled", false)
 
 	var event := {
@@ -87,8 +88,13 @@ func _simulate_mouse_move(params: Dictionary) -> Dictionary:
 		"relative": {"x": rel_x, "y": rel_y},
 		"button_mask": button_mask,
 	}
-	# When button_mask > 0 (drag), auto-enable unhandled to bypass GUI consumption
-	if unhandled or button_mask > 0:
+	# Auto-enable unhandled for drag motions (camera-pan use case) ONLY when
+	# the caller did NOT explicitly pass an "unhandled" key. If they passed
+	# one — true or false — honor it. This lets UI drag-and-drop tests opt
+	# back into normal GUI dispatch by passing unhandled: false explicitly.
+	if unhandled_explicit:
+		event["unhandled"] = unhandled
+	elif button_mask > 0:
 		event["unhandled"] = true
 	_write_commands([event])
 	return success({"sent": true, "event": event})

--- a/addons/godot_mcp/mcp_input_service.gd
+++ b/addons/godot_mcp/mcp_input_service.gd
@@ -75,14 +75,19 @@ func _dispatch_next_sequence_event() -> void:
 
 
 ## Dispatch an input event using the appropriate method.
-## Mouse drag motions (button_mask > 0) and events with "unhandled" flag
-## use push_input to bypass GUI consumption and reach _unhandled_input().
-## This fixes camera pan/drag not working when UI Controls consume mouse events.
+## Mouse drag motions (button_mask > 0) auto-promote to push_input to bypass
+## GUI consumption and reach _unhandled_input — needed for camera-pan use
+## cases where UI Controls would otherwise swallow drag events. But for UI
+## drag-and-drop *testing* we want events to reach the GUI dispatcher so
+## hit-testing and _get_drag_data / _drop_data fire. So: respect an explicit
+## "unhandled": false in the event payload — only auto-promote when the
+## caller did NOT pass an "unhandled" key. Default behavior preserved.
 func _dispatch_event(event: InputEvent, event_data: Dictionary = {}) -> void:
-	var force_unhandled: bool = event_data.get("unhandled", false)
-	# Mouse drag motion: GUI layer often consumes these before _unhandled_input
-	if not force_unhandled and event is InputEventMouseMotion and event.button_mask != 0:
-		force_unhandled = true
+	var force_unhandled: bool
+	if event_data.has("unhandled"):
+		force_unhandled = bool(event_data.get("unhandled"))
+	else:
+		force_unhandled = event is InputEventMouseMotion and event.button_mask != 0
 	if force_unhandled:
 		var vp := get_viewport()
 		if vp:


### PR DESCRIPTION
Closes #24.

Two-commit fix for the bug described in #24 — `simulate_sequence` / `simulate_mouse_move` events with `button_mask > 0` and an explicit `unhandled: false` were silently auto-promoted to `unhandled: true` at two layers, dispatching via `Viewport.push_input(event, true)` and bypassing GUI hit-testing. That made automated `Control` drag-and-drop tests impossible — `_get_drag_data` / `_can_drop_data` / `_drop_data` never fired.

## What changed

Both layers now detect "did the caller pass an `unhandled` key?" and honor the explicit value if so. Auto-promotion still fires when no key is passed — so the camera-pan use case (and any existing caller relying on the implicit behavior) sees no change.

**Commit 1** — `addons/godot_mcp/mcp_input_service.gd` `_dispatch_event`:

```gdscript
# Before
var force_unhandled: bool = event_data.get("unhandled", false)
if not force_unhandled and event is InputEventMouseMotion and event.button_mask != 0:
    force_unhandled = true

# After
var force_unhandled: bool
if event_data.has("unhandled"):
    force_unhandled = bool(event_data.get("unhandled"))
else:
    force_unhandled = event is InputEventMouseMotion and event.button_mask != 0
```

**Commit 2** — `addons/godot_mcp/commands/input_commands.gd` `_simulate_mouse_move`:

```gdscript
# Before
if unhandled or button_mask > 0:
    event["unhandled"] = true

# After
var unhandled_explicit: bool = params.has("unhandled")  # checked at top of func
# ...
if unhandled_explicit:
    event["unhandled"] = unhandled
elif button_mask > 0:
    event["unhandled"] = true
```

Both layers needed because `_simulate_mouse_move` writes the params to a queued event payload before it ever reaches `_dispatch_event` — without the params-layer fix, `unhandled: false` is overwritten to `true` before dispatch logic sees it.

## Verification

Tested against a `Control`-based drag-and-drop UI (skill-card inventory in a Godot 4.6.2 project). With both commits applied:

- `simulate_sequence` with `unhandled: false` on motions → events reach `_gui_input` on the source Control (verified via a test counter on the `gui_input` signal).
- A full press → motions (with non-zero `relative_x`/`relative_y` — see #24's bonus point on that gotcha) → release sequence engages Godot's drag state machine: `_get_drag_data` fires on the source, `_can_drop_data` is consulted on the target slot, `_drop_data` runs and mutates application state.
- Behavior with no `unhandled` key passed is identical to before — confirmed by re-running camera-pan-style flows that rely on the auto-promotion.

## Backwards compatibility

Default behavior is preserved. Callers who didn't previously pass an `unhandled` key continue to get `button_mask > 0` motions auto-promoted to `unhandled: true`. The only behavior change is for callers who explicitly pass `unhandled: false` — previously their value was silently discarded; now it's honored.

## Out of scope for this PR

The undocumented `relative_x` / `relative_y` requirement for drag-detection (mentioned in #24 bonus) is a separate concern — it's a tool-doc update, not a code change. Happy to follow up with a docs PR if useful.