### PR TITLE
Prevent MCP addon from overwriting open editor resources

### DIFF
--- a/addons/godot_mcp/commands/animation_commands.gd
+++ b/addons/godot_mcp/commands/animation_commands.gd
@@ -63,7 +63,7 @@ func _create_animation(params: Dictionary) -> Dictionary:
 
 	var anim := Animation.new()
 	anim.length = length
-	anim.loop_mode = loop_mode
+	anim.loop_mode = loop_mode as Animation.LoopMode
 
 	var lib := player.get_animation_library("")
 	var created_library := false

--- a/addons/godot_mcp/commands/animation_commands.gd
+++ b/addons/godot_mcp/commands/animation_commands.gd
@@ -66,11 +66,24 @@ func _create_animation(params: Dictionary) -> Dictionary:
 	anim.loop_mode = loop_mode
 
 	var lib := player.get_animation_library("")
+	var created_library := false
 	if lib == null:
 		lib = AnimationLibrary.new()
-		player.add_animation_library("", lib)
+		created_library = true
 
-	lib.add_animation(anim_name, anim)
+	if lib.has_animation(anim_name):
+		return error_invalid_params("Animation '%s' already exists" % anim_name)
+
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Create animation %s" % anim_name)
+	if created_library:
+		undo_redo.add_do_method(player, "add_animation_library", "", lib)
+		undo_redo.add_do_reference(lib)
+		undo_redo.add_undo_method(player, "remove_animation_library", "")
+	undo_redo.add_do_method(lib, "add_animation", anim_name, anim)
+	undo_redo.add_do_reference(anim)
+	undo_redo.add_undo_method(lib, "remove_animation", anim_name)
+	undo_redo.commit_action()
 
 	return success({"name": anim_name, "length": length, "created": true})
 
@@ -111,15 +124,20 @@ func _add_animation_track(params: Dictionary) -> Dictionary:
 		"blend_shape": track_type = Animation.TYPE_BLEND_SHAPE
 		_: track_type = Animation.TYPE_VALUE
 
-	var track_idx := anim.add_track(track_type)
-	anim.track_set_path(track_idx, NodePath(track_path))
+	var track_idx := anim.get_track_count()
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Add animation track")
+	undo_redo.add_do_method(anim, "add_track", track_type, track_idx)
+	undo_redo.add_do_method(anim, "track_set_path", track_idx, NodePath(track_path))
 
 	var update_mode_str: String = optional_string(params, "update_mode", "")
 	if not update_mode_str.is_empty() and track_type == Animation.TYPE_VALUE:
 		match update_mode_str:
-			"continuous": anim.value_track_set_update_mode(track_idx, Animation.UPDATE_CONTINUOUS)
-			"discrete": anim.value_track_set_update_mode(track_idx, Animation.UPDATE_DISCRETE)
-			"capture": anim.value_track_set_update_mode(track_idx, Animation.UPDATE_CAPTURE)
+			"continuous": undo_redo.add_do_method(anim, "value_track_set_update_mode", track_idx, Animation.UPDATE_CONTINUOUS)
+			"discrete": undo_redo.add_do_method(anim, "value_track_set_update_mode", track_idx, Animation.UPDATE_DISCRETE)
+			"capture": undo_redo.add_do_method(anim, "value_track_set_update_mode", track_idx, Animation.UPDATE_CAPTURE)
+	undo_redo.add_undo_method(anim, "remove_track", track_idx)
+	undo_redo.commit_action()
 
 	return success({"track_index": track_idx, "track_path": track_path, "track_type": track_type_str})
 
@@ -159,11 +177,19 @@ func _set_animation_keyframe(params: Dictionary) -> Dictionary:
 			if parsed != null:
 				value = parsed
 
-	var key_idx := anim.track_insert_key(track_index, time, value)
-
 	var easing: float = float(params.get("easing", 1.0))
-	if easing != 1.0:
-		anim.track_set_key_transition(track_index, key_idx, easing)
+	var old_key_idx := _find_animation_key_at_time(anim, track_index, time)
+	var had_old_key := old_key_idx >= 0
+	var old_value: Variant = anim.track_get_key_value(track_index, old_key_idx) if had_old_key else null
+	var old_easing: float = anim.track_get_key_transition(track_index, old_key_idx) if had_old_key else 1.0
+
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Set animation keyframe")
+	undo_redo.add_do_method(self, "_upsert_animation_key", anim, track_index, time, value, easing)
+	undo_redo.add_undo_method(self, "_restore_animation_key", anim, track_index, time, had_old_key, old_value, old_easing)
+	undo_redo.commit_action()
+
+	var key_idx := _find_animation_key_at_time(anim, track_index, time)
 
 	return success({"track_index": track_index, "time": time, "key_index": key_idx, "easing": anim.track_get_key_transition(track_index, key_idx)})
 
@@ -233,5 +259,40 @@ func _remove_animation(params: Dictionary) -> Dictionary:
 	if lib == null or not lib.has_animation(anim_name):
 		return error_not_found("Animation '%s'" % anim_name)
 
-	lib.remove_animation(anim_name)
+	var anim := lib.get_animation(anim_name)
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Remove animation %s" % anim_name)
+	undo_redo.add_do_method(lib, "remove_animation", anim_name)
+	undo_redo.add_undo_method(lib, "add_animation", anim_name, anim)
+	undo_redo.add_undo_reference(anim)
+	undo_redo.commit_action()
 	return success({"name": anim_name, "removed": true})
+
+
+func _find_animation_key_at_time(anim: Animation, track_index: int, time: float) -> int:
+	for key_index: int in anim.track_get_key_count(track_index):
+		if is_equal_approx(anim.track_get_key_time(track_index, key_index), time):
+			return key_index
+	return -1
+
+
+func _upsert_animation_key(anim: Animation, track_index: int, time: float, value: Variant, easing: float) -> void:
+	var key_idx := _find_animation_key_at_time(anim, track_index, time)
+	if key_idx < 0:
+		key_idx = anim.track_insert_key(track_index, time, value)
+	else:
+		anim.track_set_key_value(track_index, key_idx, value)
+	if easing != 1.0:
+		anim.track_set_key_transition(track_index, key_idx, easing)
+
+
+func _restore_animation_key(anim: Animation, track_index: int, time: float, had_old_key: bool, old_value: Variant, old_easing: float) -> void:
+	var key_idx := _find_animation_key_at_time(anim, track_index, time)
+	if had_old_key:
+		if key_idx < 0:
+			key_idx = anim.track_insert_key(track_index, time, old_value)
+		else:
+			anim.track_set_key_value(track_index, key_idx, old_value)
+		anim.track_set_key_transition(track_index, key_idx, old_easing)
+	elif key_idx >= 0:
+		anim.track_remove_key(track_index, key_idx)

--- a/addons/godot_mcp/commands/animation_tree_commands.gd
+++ b/addons/godot_mcp/commands/animation_tree_commands.gd
@@ -93,8 +93,7 @@ func _create_animation_tree(params: Dictionary) -> Dictionary:
 	if not anim_player_path.is_empty():
 		tree.anim_player = NodePath(anim_player_path)
 
-	parent.add_child(tree, true)
-	tree.owner = root
+	add_child_with_undo(parent, tree, root, "MCP: Create AnimationTree")
 
 	return success({
 		"name": tree.name,
@@ -281,7 +280,12 @@ func _add_state_machine_state(params: Dictionary) -> Dictionary:
 		_:
 			return error_invalid_params("Unknown state_type: '%s'. Use 'animation', 'blend_tree', or 'state_machine'" % state_type)
 
-	sm.add_node(StringName(state_name), node, position)
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Add state machine state")
+	undo_redo.add_do_method(sm, "add_node", StringName(state_name), node, position)
+	undo_redo.add_do_reference(node)
+	undo_redo.add_undo_method(sm, "remove_node", StringName(state_name))
+	undo_redo.commit_action()
 
 	return success({
 		"state_name": state_name,
@@ -315,7 +319,14 @@ func _remove_state_machine_state(params: Dictionary) -> Dictionary:
 	if not sm.has_node(StringName(state_name)):
 		return error_not_found("State '%s'" % state_name)
 
-	sm.remove_node(StringName(state_name))
+	var old_node := sm.get_node(StringName(state_name))
+	var old_position := sm.get_node_position(StringName(state_name))
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Remove state machine state")
+	undo_redo.add_do_method(sm, "remove_node", StringName(state_name))
+	undo_redo.add_undo_method(sm, "add_node", StringName(state_name), old_node, old_position)
+	undo_redo.add_undo_reference(old_node)
+	undo_redo.commit_action()
 
 	return success({"state_name": state_name, "removed": true})
 
@@ -379,7 +390,12 @@ func _add_state_machine_transition(params: Dictionary) -> Dictionary:
 	if params.has("xfade_time"):
 		transition.xfade_time = float(params["xfade_time"])
 
-	sm.add_transition(StringName(from_state), StringName(to_state), transition)
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Add state machine transition")
+	undo_redo.add_do_method(sm, "add_transition", StringName(from_state), StringName(to_state), transition)
+	undo_redo.add_do_reference(transition)
+	undo_redo.add_undo_method(sm, "remove_transition", StringName(from_state), StringName(to_state))
+	undo_redo.commit_action()
 
 	return success({
 		"from": from_state,
@@ -427,7 +443,18 @@ func _remove_state_machine_transition(params: Dictionary) -> Dictionary:
 	if not found:
 		return error_not_found("Transition from '%s' to '%s'" % [from_state, to_state])
 
-	sm.remove_transition(StringName(from_state), StringName(to_state))
+	var transition: AnimationNodeStateMachineTransition = null
+	for i in sm.get_transition_count():
+		if str(sm.get_transition_from(i)) == from_state and str(sm.get_transition_to(i)) == to_state:
+			transition = sm.get_transition(i)
+			break
+
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Remove state machine transition")
+	undo_redo.add_do_method(sm, "remove_transition", StringName(from_state), StringName(to_state))
+	undo_redo.add_undo_method(sm, "add_transition", StringName(from_state), StringName(to_state), transition)
+	undo_redo.add_undo_reference(transition)
+	undo_redo.commit_action()
 
 	return success({"from": from_state, "to": to_state, "removed": true})
 
@@ -467,9 +494,9 @@ func _set_blend_tree_node(params: Dictionary) -> Dictionary:
 	var position_y: float = float(params.get("position_y", 0.0))
 	var position := Vector2(position_x, position_y)
 
-	# Remove existing node if replacing
-	if bt.has_node(StringName(bt_node_name)):
-		bt.remove_node(StringName(bt_node_name))
+	var had_old_node := bt.has_node(StringName(bt_node_name))
+	var old_node: AnimationNode = bt.get_node(StringName(bt_node_name)) if had_old_node else null
+	var old_position := bt.get_node_position(StringName(bt_node_name)) if had_old_node else Vector2.ZERO
 
 	var node: AnimationNode
 	match bt_node_type:
@@ -500,13 +527,22 @@ func _set_blend_tree_node(params: Dictionary) -> Dictionary:
 		_:
 			return error_invalid_params("Unknown bt_node_type: '%s'. Use: Animation, Add2, Blend2, Add3, Blend3, TimeScale, TimeSeek, Transition, OneShot, Sub2" % bt_node_type)
 
-	bt.add_node(StringName(bt_node_name), node, position)
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Set blend tree node")
+	if had_old_node:
+		undo_redo.add_do_method(bt, "remove_node", StringName(bt_node_name))
+		undo_redo.add_undo_method(bt, "add_node", StringName(bt_node_name), old_node, old_position)
+		undo_redo.add_undo_reference(old_node)
+	undo_redo.add_do_method(bt, "add_node", StringName(bt_node_name), node, position)
+	undo_redo.add_do_reference(node)
+	undo_redo.add_undo_method(bt, "remove_node", StringName(bt_node_name))
 
 	# Connect to another node if specified
 	var connect_to: String = optional_string(params, "connect_to", "")
 	var connect_port: int = optional_int(params, "connect_port", 0)
 	if not connect_to.is_empty():
-		bt.connect_node(StringName(connect_to), connect_port, StringName(bt_node_name))
+		undo_redo.add_do_method(bt, "connect_node", StringName(connect_to), connect_port, StringName(bt_node_name))
+	undo_redo.commit_action()
 
 	return success({
 		"blend_tree_state": bt_state,
@@ -551,7 +587,7 @@ func _set_tree_parameter(params: Dictionary) -> Dictionary:
 			if parsed != null:
 				value = parsed
 
-	tree.set(parameter, value)
+	set_property_with_undo(tree, parameter, value, "MCP: Set AnimationTree parameter")
 
 	# Read back to confirm
 	var actual = tree.get(parameter)

--- a/addons/godot_mcp/commands/animation_tree_commands.gd
+++ b/addons/godot_mcp/commands/animation_tree_commands.gd
@@ -218,7 +218,6 @@ func _read_blend_tree_structure(bt: AnimationNodeBlendTree) -> Dictionary:
 		nodes_info.append(node_info)
 
 	# Read connections
-	var connections: Array = []
 	# BlendTree connections are stored as "node_connections" in properties
 	# We can read them from the resource property list
 	for prop in prop_list:
@@ -544,12 +543,15 @@ func _set_blend_tree_node(params: Dictionary) -> Dictionary:
 		undo_redo.add_do_method(bt, "connect_node", StringName(connect_to), connect_port, StringName(bt_node_name))
 	undo_redo.commit_action()
 
+	var connected_to_value: Variant = null
+	if not connect_to.is_empty():
+		connected_to_value = connect_to
 	return success({
 		"blend_tree_state": bt_state,
 		"bt_node_name": bt_node_name,
 		"bt_node_type": bt_node_type,
 		"position": {"x": position_x, "y": position_y},
-		"connected_to": connect_to if not connect_to.is_empty() else null,
+		"connected_to": connected_to_value,
 		"added": true,
 	})
 

--- a/addons/godot_mcp/commands/audio_commands.gd
+++ b/addons/godot_mcp/commands/audio_commands.gd
@@ -316,6 +316,9 @@ func _add_audio_player(params: Dictionary) -> Dictionary:
 	var parent := find_node_by_path(node_path)
 	if parent == null:
 		return error_not_found("Node at '%s'" % node_path)
+	var root := get_edited_root()
+	if root == null:
+		return error_no_scene()
 
 	var player: Node = null
 	match player_type:
@@ -369,8 +372,7 @@ func _add_audio_player(params: Dictionary) -> Dictionary:
 		if params.has("unit_size"):
 			(player as AudioStreamPlayer3D).unit_size = float(params["unit_size"])
 
-	parent.add_child(player)
-	player.owner = get_edited_root()
+	add_child_with_undo(parent, player, root, "MCP: Add audio player")
 
 	return success({
 		"name": player_name,

--- a/addons/godot_mcp/commands/audio_commands.gd
+++ b/addons/godot_mcp/commands/audio_commands.gd
@@ -248,7 +248,7 @@ func _add_audio_bus_effect(params: Dictionary) -> Dictionary:
 		"distortion":
 			var e := AudioEffectDistortion.new()
 			if effect_params.has("mode"):
-				e.mode = int(effect_params["mode"])
+					e.mode = int(effect_params["mode"]) as AudioEffectDistortion.Mode
 			if effect_params.has("pre_gain"):
 				e.pre_gain = float(effect_params["pre_gain"])
 			if effect_params.has("post_gain"):
@@ -368,7 +368,7 @@ func _add_audio_player(params: Dictionary) -> Dictionary:
 		if params.has("max_distance"):
 			(player as AudioStreamPlayer3D).max_distance = float(params["max_distance"])
 		if params.has("attenuation_model"):
-			(player as AudioStreamPlayer3D).attenuation_model = int(params["attenuation_model"])
+			(player as AudioStreamPlayer3D).attenuation_model = int(params["attenuation_model"]) as AudioStreamPlayer3D.AttenuationModel
 		if params.has("unit_size"):
 			(player as AudioStreamPlayer3D).unit_size = float(params["unit_size"])
 

--- a/addons/godot_mcp/commands/base_command.gd
+++ b/addons/godot_mcp/commands/base_command.gd
@@ -42,6 +42,10 @@ func error_internal(message: String) -> Dictionary:
 	return error(-32603, "Internal error: %s" % message)
 
 
+func error_conflict(message: String, data: Dictionary = {}) -> Dictionary:
+	return error(-32009, message, data)
+
+
 ## Get required string param
 func require_string(params: Dictionary, key: String) -> Array:
 	if not params.has(key) or not params[key] is String or (params[key] as String).is_empty():
@@ -113,6 +117,118 @@ func get_edited_root() -> Node:
 ## Get UndoRedo
 func get_undo_redo() -> EditorUndoRedoManager:
 	return editor_plugin.get_undo_redo()
+
+
+func normalize_project_path(path: String) -> String:
+	if path.is_empty():
+		return ""
+	if path.begins_with("res://") or path.begins_with("user://"):
+		return path.simplify_path()
+	return ProjectSettings.localize_path(path).simplify_path()
+
+
+func is_scene_resource_path(path: String) -> bool:
+	var ext := path.get_extension().to_lower()
+	return ext == "tscn" or ext == "scn"
+
+
+func get_open_scene_paths() -> Array[String]:
+	var paths: Array[String] = []
+	var open_scenes: PackedStringArray = get_editor().get_open_scenes()
+	for scene_path: String in open_scenes:
+		var normalized := normalize_project_path(scene_path)
+		if not normalized.is_empty() and normalized not in paths:
+			paths.append(normalized)
+
+	var root := get_edited_root()
+	if root != null and not root.scene_file_path.is_empty():
+		var active_path := normalize_project_path(root.scene_file_path)
+		if active_path not in paths:
+			paths.append(active_path)
+	return paths
+
+
+func is_scene_path_open(path: String) -> bool:
+	var normalized := normalize_project_path(path)
+	if normalized.is_empty():
+		return false
+	return normalized in get_open_scene_paths()
+
+
+func is_active_scene_path(path: String) -> bool:
+	var root := get_edited_root()
+	if root == null:
+		return false
+	return normalize_project_path(root.scene_file_path) == normalize_project_path(path)
+
+
+func guard_offline_scene_save(path: String) -> Dictionary:
+	if is_scene_resource_path(path) and is_scene_path_open(path):
+		return error_conflict(
+			"Refusing to save open scene '%s' outside the Godot editor state" % normalize_project_path(path),
+			{
+				"path": normalize_project_path(path),
+				"open_scenes": get_open_scene_paths(),
+				"suggestion": "Use live editor changes plus save_scene, or close the scene before offline edits.",
+			}
+		)
+	return {}
+
+
+func is_text_resource_open_in_script_editor(path: String) -> bool:
+	var target := normalize_project_path(path)
+	if target.is_empty():
+		return false
+	var script_editor := get_editor().get_script_editor()
+	if script_editor == null:
+		return false
+	for open_resource in script_editor.get_open_scripts():
+		if open_resource is Resource:
+			var resource_path := normalize_project_path((open_resource as Resource).resource_path)
+			if resource_path == target:
+				return true
+	return false
+
+
+func guard_text_resource_write(path: String, force: bool) -> Dictionary:
+	if not force and is_text_resource_open_in_script_editor(path):
+		return error_conflict(
+			"Refusing to write open text resource '%s' outside the script editor state" % normalize_project_path(path),
+			{
+				"path": normalize_project_path(path),
+				"suggestion": "Close the file in Godot's script editor or pass force=true to overwrite it deliberately.",
+			}
+		)
+	return {}
+
+
+func mark_current_scene_unsaved() -> void:
+	var ei := get_editor()
+	if ei != null and ei.has_method("mark_scene_as_unsaved"):
+		ei.mark_scene_as_unsaved()
+
+
+func add_child_with_undo(parent: Node, child: Node, root: Node, action_name: String) -> void:
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action(action_name)
+	undo_redo.add_do_method(parent, "add_child", child)
+	undo_redo.add_do_method(child, "set_owner", root)
+	undo_redo.add_do_reference(child)
+	undo_redo.add_undo_method(parent, "remove_child", child)
+	undo_redo.commit_action()
+
+
+func set_property_with_undo(target: Object, property: String, new_value: Variant, action_name: String) -> void:
+	var old_value: Variant = target.get(property)
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action(action_name)
+	undo_redo.add_do_property(target, property, new_value)
+	if new_value is Resource:
+		undo_redo.add_do_reference(new_value)
+	undo_redo.add_undo_property(target, property, old_value)
+	if old_value is Resource:
+		undo_redo.add_undo_reference(old_value)
+	undo_redo.commit_action()
 
 
 ## Find node by path in edited scene

--- a/addons/godot_mcp/commands/base_command.gd
+++ b/addons/godot_mcp/commands/base_command.gd
@@ -175,10 +175,17 @@ func guard_offline_scene_save(path: String) -> Dictionary:
 	return {}
 
 
+func is_shader_resource_path(path: String) -> bool:
+	var ext := path.get_extension().to_lower()
+	return ext == "gdshader" or ext == "gdshaderinc" or ext == "shader"
+
+
 func is_text_resource_open_in_script_editor(path: String) -> bool:
 	var target := normalize_project_path(path)
 	if target.is_empty():
 		return false
+	if is_shader_resource_path(target) and ResourceLoader.has_cached(target):
+		return true
 	var script_editor := get_editor().get_script_editor()
 	if script_editor == null:
 		return false

--- a/addons/godot_mcp/commands/base_command.gd
+++ b/addons/godot_mcp/commands/base_command.gd
@@ -111,7 +111,7 @@ func get_editor() -> EditorInterface:
 
 ## Get the edited scene root
 func get_edited_root() -> Node:
-	return get_editor().get_edited_scene_root()
+	return EditorInterface.get_edited_scene_root()
 
 
 ## Get UndoRedo
@@ -134,7 +134,7 @@ func is_scene_resource_path(path: String) -> bool:
 
 func get_open_scene_paths() -> Array[String]:
 	var paths: Array[String] = []
-	var open_scenes: PackedStringArray = get_editor().get_open_scenes()
+	var open_scenes: PackedStringArray = EditorInterface.get_open_scenes()
 	for scene_path: String in open_scenes:
 		var normalized := normalize_project_path(scene_path)
 		if not normalized.is_empty() and normalized not in paths:
@@ -186,7 +186,7 @@ func is_text_resource_open_in_script_editor(path: String) -> bool:
 		return false
 	if is_shader_resource_path(target) and ResourceLoader.has_cached(target):
 		return true
-	var script_editor := get_editor().get_script_editor()
+	var script_editor := EditorInterface.get_script_editor()
 	if script_editor == null:
 		return false
 	for open_resource in script_editor.get_open_scripts():
@@ -210,9 +210,8 @@ func guard_text_resource_write(path: String, force: bool) -> Dictionary:
 
 
 func mark_current_scene_unsaved() -> void:
-	var ei := get_editor()
-	if ei != null and ei.has_method("mark_scene_as_unsaved"):
-		ei.mark_scene_as_unsaved()
+	if EditorInterface.has_method("mark_scene_as_unsaved"):
+		EditorInterface.mark_scene_as_unsaved()
 
 
 func add_child_with_undo(parent: Node, child: Node, root: Node, action_name: String) -> void:

--- a/addons/godot_mcp/commands/batch_commands.gd
+++ b/addons/godot_mcp/commands/batch_commands.gd
@@ -327,7 +327,7 @@ func _cross_scene_set_property(params: Dictionary) -> Dictionary:
 		if not changes.is_empty():
 			if not dry_run:
 				var guard := guard_offline_scene_save(normalized_scene_path)
-				if guard != null:
+				if not guard.is_empty():
 					instance.free()
 					return guard
 				for change: Dictionary in changes:

--- a/addons/godot_mcp/commands/batch_commands.gd
+++ b/addons/godot_mcp/commands/batch_commands.gd
@@ -110,18 +110,25 @@ func _batch_set_property(params: Dictionary) -> Dictionary:
 		return error_no_scene()
 
 	var affected: Array = []
-	_batch_set_recursive(root, root, type_name, property, value, affected)
+	var changes: Array = []
+	_batch_collect_property_changes(root, root, type_name, property, value, affected, changes)
+	if not changes.is_empty():
+		_apply_property_changes_with_undo(changes, property, "MCP: Batch set %s" % property)
 
 	return success({"property": property, "affected": affected, "count": affected.size()})
 
 
-func _batch_set_recursive(node: Node, root: Node, type_name: String, property: String, value: Variant, affected: Array) -> void:
+func _batch_collect_property_changes(node: Node, root: Node, type_name: String, property: String, value: Variant, affected: Array, changes: Array) -> void:
 	if node.is_class(type_name) or node.get_class() == type_name:
 		if property in node:
-			node.set(property, value)
 			affected.append(str(root.get_path_to(node)))
+			changes.append({
+				"node": node,
+				"old_value": node.get(property),
+				"new_value": value,
+			})
 	for child in node.get_children():
-		_batch_set_recursive(child, root, type_name, property, value, affected)
+		_batch_collect_property_changes(child, root, type_name, property, value, affected, changes)
 
 
 func _batch_add_nodes(params: Dictionary) -> Dictionary:
@@ -138,9 +145,6 @@ func _batch_add_nodes(params: Dictionary) -> Dictionary:
 
 	var created: Array = []
 	var errors: Array = []
-
-	var undo_redo := get_undo_redo()
-	undo_redo.create_action("MCP: Batch add %d nodes" % nodes_data.size())
 
 	for i: int in nodes_data.size():
 		var entry: Dictionary = nodes_data[i]
@@ -178,15 +182,7 @@ func _batch_add_nodes(params: Dictionary) -> Dictionary:
 				var target_type := typeof(current)
 				node.set(prop_name, PropertyParser.parse_value(properties[prop_name], target_type))
 
-		# Add directly so subsequent nodes can reference this as parent
-		parent.add_child(node)
-		node.set_owner(root)
-
-		# Register undo/redo (do methods re-add on redo, undo removes)
-		undo_redo.add_do_method(parent, "add_child", node)
-		undo_redo.add_do_method(node, "set_owner", root)
-		undo_redo.add_do_reference(node)
-		undo_redo.add_undo_method(parent, "remove_child", node)
+		add_child_with_undo(parent, node, root, "MCP: Batch add %s" % type)
 
 		created.append({
 			"index": i,
@@ -195,9 +191,6 @@ func _batch_add_nodes(params: Dictionary) -> Dictionary:
 			"parent": parent_path,
 			"node_path": str(root.get_path_to(node)),
 		})
-
-	# Commit without re-executing do methods (nodes already added)
-	undo_redo.commit_action(false)
 
 	var result := {"created": created, "count": created.size()}
 	if not errors.is_empty():
@@ -286,13 +279,40 @@ func _cross_scene_set_property(params: Dictionary) -> Dictionary:
 
 	var path_filter: String = optional_string(params, "path_filter", "res://")
 	var exclude_addons: bool = optional_bool(params, "exclude_addons", true)
+	var force: bool = optional_bool(params, "force", false)
+	var dry_run: bool = optional_bool(params, "dry_run", not force)
+	if not dry_run and not force:
+		return error_invalid_params("cross_scene_set_property requires force=true when dry_run=false")
 
 	var scenes_affected: Array = []
+	var skipped_open_scenes: Array = []
 	var total_nodes: int = 0
 	var scene_files: Array = []
 	_collect_scene_files(path_filter, scene_files, exclude_addons)
 
 	for scene_path: String in scene_files:
+		var normalized_scene_path := normalize_project_path(scene_path)
+
+		if is_scene_path_open(normalized_scene_path):
+			if is_active_scene_path(normalized_scene_path) and force and not dry_run:
+				var root := get_edited_root()
+				var live_changes: Array = []
+				var live_affected_nodes: Array = []
+				_cross_scene_collect_changes(root, root, type_name, property, value, live_affected_nodes, live_changes)
+				if not live_changes.is_empty():
+					_apply_property_changes_with_undo(live_changes, property, "MCP: Cross-scene set %s" % property)
+					scenes_affected.append({
+						"scene": normalized_scene_path,
+						"nodes": live_affected_nodes,
+						"count": live_affected_nodes.size(),
+						"mode": "live_open_scene",
+					})
+					total_nodes += live_affected_nodes.size()
+			else:
+				var reason := "open scene skipped during dry_run" if dry_run else "open scene is not the active editor scene"
+				skipped_open_scenes.append({"scene": normalized_scene_path, "reason": reason})
+			continue
+
 		var packed: PackedScene = ResourceLoader.load(scene_path) as PackedScene
 		if packed == null:
 			continue
@@ -301,17 +321,32 @@ func _cross_scene_set_property(params: Dictionary) -> Dictionary:
 			continue
 
 		var affected_nodes: Array = []
-		_cross_scene_set_recursive(instance, instance, type_name, property, value, affected_nodes)
+		var changes: Array = []
+		_cross_scene_collect_changes(instance, instance, type_name, property, value, affected_nodes, changes)
 
-		if not affected_nodes.is_empty():
+		if not changes.is_empty():
+			if not dry_run:
+				var guard := guard_offline_scene_save(normalized_scene_path)
+				if guard != null:
+					instance.free()
+					return guard
+				for change: Dictionary in changes:
+					(change["node"] as Node).set(property, value)
 			# Pack and save
-			var new_packed := PackedScene.new()
-			new_packed.pack(instance)
-			ResourceSaver.save(new_packed, scene_path)
+				var new_packed := PackedScene.new()
+				var pack_err := new_packed.pack(instance)
+				if pack_err != OK:
+					instance.free()
+					return error_internal("Failed to pack scene '%s': %s" % [normalized_scene_path, error_string(pack_err)])
+				var save_err := ResourceSaver.save(new_packed, normalized_scene_path)
+				if save_err != OK:
+					instance.free()
+					return error_internal("Failed to save scene '%s': %s" % [normalized_scene_path, error_string(save_err)])
 			scenes_affected.append({
-				"scene": scene_path,
+				"scene": normalized_scene_path,
 				"nodes": affected_nodes,
 				"count": affected_nodes.size(),
+				"mode": "dry_run" if dry_run else "offline_saved",
 			})
 			total_nodes += affected_nodes.size()
 
@@ -324,9 +359,13 @@ func _cross_scene_set_property(params: Dictionary) -> Dictionary:
 	return success({
 		"type": type_name,
 		"property": property,
+		"dry_run": dry_run,
+		"force": force,
 		"scenes_affected": scenes_affected,
+		"skipped_open_scenes": skipped_open_scenes,
 		"total_scenes": scenes_affected.size(),
 		"total_nodes": total_nodes,
+		"message": "Dry run only. Re-run with force=true and dry_run=false to write closed scenes and live-edit the active open scene." if dry_run else "Changes applied.",
 	})
 
 
@@ -352,13 +391,27 @@ func _collect_scene_files(path: String, files: Array, exclude_addons: bool) -> v
 	dir.list_dir_end()
 
 
-func _cross_scene_set_recursive(node: Node, root: Node, type_name: String, property: String, value: Variant, affected: Array) -> void:
+func _cross_scene_collect_changes(node: Node, root: Node, type_name: String, property: String, value: Variant, affected: Array, changes: Array) -> void:
 	if node.is_class(type_name) or node.get_class() == type_name:
 		if property in node:
-			node.set(property, value)
 			affected.append(str(root.get_path_to(node)))
+			changes.append({
+				"node": node,
+				"old_value": node.get(property),
+				"new_value": value,
+			})
 	for child in node.get_children():
-		_cross_scene_set_recursive(child, root, type_name, property, value, affected)
+		_cross_scene_collect_changes(child, root, type_name, property, value, affected, changes)
+
+
+func _apply_property_changes_with_undo(changes: Array, property: String, action_name: String) -> void:
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action(action_name)
+	for change: Dictionary in changes:
+		var node: Node = change["node"]
+		undo_redo.add_do_property(node, property, change["new_value"])
+		undo_redo.add_undo_property(node, property, change["old_value"])
+	undo_redo.commit_action()
 
 
 func _get_scene_dependencies(params: Dictionary) -> Dictionary:

--- a/addons/godot_mcp/commands/batch_commands.gd
+++ b/addons/godot_mcp/commands/batch_commands.gd
@@ -354,7 +354,7 @@ func _cross_scene_set_property(params: Dictionary) -> Dictionary:
 
 	# Rescan filesystem so editor picks up changes
 	if not scenes_affected.is_empty():
-		get_editor().get_resource_filesystem().scan()
+		EditorInterface.get_resource_filesystem().scan()
 
 	return success({
 		"type": type_name,

--- a/addons/godot_mcp/commands/editor_commands.gd
+++ b/addons/godot_mcp/commands/editor_commands.gd
@@ -355,6 +355,10 @@ func _execute_editor_script(params: Dictionary) -> Dictionary:
 	if result[1] != null:
 		return result[1]
 	var code: String = result[0]
+	var allow_unsafe_editor_io: bool = optional_bool(params, "allow_unsafe_editor_io", false)
+	var unsafe_guard := _guard_editor_script_file_io(code, allow_unsafe_editor_io)
+	if not unsafe_guard.is_empty():
+		return unsafe_guard
 
 	# Wrap user code in a @tool script
 	var wrapped_code := """@tool
@@ -406,6 +410,40 @@ func run() -> Variant:
 		"output": mcp_output,
 		"return_value": str(output) if output != null else null,
 	})
+
+
+func _guard_editor_script_file_io(code: String, allow_unsafe_editor_io: bool) -> Dictionary:
+	if allow_unsafe_editor_io:
+		return {}
+	var compact := code.replace(" ", "").replace("\t", "").replace("\n", "")
+	var unsafe_patterns: Array[String] = []
+	if compact.contains("ResourceSaver.save("):
+		unsafe_patterns.append("ResourceSaver.save")
+	if compact.contains("ProjectSettings.save("):
+		unsafe_patterns.append("ProjectSettings.save")
+	if compact.contains("ConfigFile.save("):
+		unsafe_patterns.append("ConfigFile.save")
+	if compact.contains("FileAccess.open(") and _contains_any(compact, ["FileAccess.WRITE", "FileAccess.READ_WRITE", "FileAccess.WRITE_READ"]):
+		unsafe_patterns.append("FileAccess.open WRITE")
+	if _contains_any(compact, ["DirAccess.remove_absolute(", "DirAccess.rename_absolute(", "DirAccess.copy_absolute(", "DirAccess.make_dir_absolute(", "DirAccess.make_dir_recursive_absolute("]):
+		unsafe_patterns.append("DirAccess filesystem mutation")
+	if unsafe_patterns.is_empty():
+		return {}
+	return error_conflict(
+		"Refusing to execute editor script with direct file/resource write APIs",
+		{
+			"unsafe_patterns": unsafe_patterns,
+			"open_scenes": get_open_scene_paths(),
+			"suggestion": "Use dedicated MCP commands and save_scene for editor-owned resources, or pass allow_unsafe_editor_io=true only when no open editor resource can be overwritten.",
+		}
+	)
+
+
+func _contains_any(value: String, needles: Array[String]) -> bool:
+	for needle: String in needles:
+		if value.contains(needle):
+			return true
+	return false
 
 
 func _indent_code(code: String) -> String:

--- a/addons/godot_mcp/commands/navigation_commands.gd
+++ b/addons/godot_mcp/commands/navigation_commands.gd
@@ -37,6 +37,9 @@ func _setup_navigation_region(params: Dictionary) -> Dictionary:
 	var node := find_node_by_path(node_path)
 	if node == null:
 		return error_not_found("Node at '%s'" % node_path)
+	var root := get_edited_root()
+	if root == null:
+		return error_no_scene()
 
 	var force_mode: String = optional_string(params, "mode", "auto")
 	var is_3d: bool
@@ -61,8 +64,7 @@ func _setup_navigation_region(params: Dictionary) -> Dictionary:
 		if params.has("navigation_layers"):
 			region.navigation_layers = int(params["navigation_layers"])
 
-		node.add_child(region, true)
-		region.owner = get_edited_root()
+		add_child_with_undo(node, region, root, "MCP: Add NavigationRegion3D")
 
 		return success({
 			"node_path": str(region.get_path()),
@@ -97,8 +99,7 @@ func _setup_navigation_region(params: Dictionary) -> Dictionary:
 		if params.has("navigation_layers"):
 			region.navigation_layers = int(params["navigation_layers"])
 
-		node.add_child(region, true)
-		region.owner = get_edited_root()
+		add_child_with_undo(node, region, root, "MCP: Add NavigationRegion2D")
 
 		return success({
 			"node_path": str(region.get_path()),
@@ -117,12 +118,16 @@ func _bake_navigation_mesh(params: Dictionary) -> Dictionary:
 	var node := find_node_by_path(node_path)
 	if node == null:
 		return error_not_found("Node at '%s'" % node_path)
+	var root := get_edited_root()
+	if root == null:
+		return error_no_scene()
 
 	if node is NavigationRegion3D:
 		var region: NavigationRegion3D = node as NavigationRegion3D
 		if region.navigation_mesh == null:
 			return error_invalid_params("NavigationRegion3D has no NavigationMesh resource")
 		region.bake_navigation_mesh()
+		mark_current_scene_unsaved()
 		return success({
 			"node_path": node_path,
 			"type": "NavigationRegion3D",
@@ -151,6 +156,7 @@ func _bake_navigation_mesh(params: Dictionary) -> Dictionary:
 					region.navigation_polygon.remove_outline(0)
 				region.navigation_polygon.add_outline(outline)
 				region.navigation_polygon.make_polygons_from_outlines()
+				mark_current_scene_unsaved()
 				return success({
 					"node_path": node_path,
 					"type": "NavigationRegion2D",
@@ -162,6 +168,7 @@ func _bake_navigation_mesh(params: Dictionary) -> Dictionary:
 		else:
 			# Try baking from source geometry
 			region.bake_navigation_polygon()
+			mark_current_scene_unsaved()
 			return success({
 				"node_path": node_path,
 				"type": "NavigationRegion2D",
@@ -180,6 +187,9 @@ func _setup_navigation_agent(params: Dictionary) -> Dictionary:
 	var node := find_node_by_path(node_path)
 	if node == null:
 		return error_not_found("Node at '%s'" % node_path)
+	var root := get_edited_root()
+	if root == null:
+		return error_no_scene()
 
 	var force_mode: String = optional_string(params, "mode", "auto")
 	var is_3d: bool
@@ -211,8 +221,7 @@ func _setup_navigation_agent(params: Dictionary) -> Dictionary:
 		if params.has("navigation_layers"):
 			agent.navigation_layers = int(params["navigation_layers"])
 
-		node.add_child(agent, true)
-		agent.owner = get_edited_root()
+		add_child_with_undo(node, agent, root, "MCP: Add NavigationAgent3D")
 
 		return success({
 			"node_path": str(agent.get_path()),
@@ -244,8 +253,7 @@ func _setup_navigation_agent(params: Dictionary) -> Dictionary:
 		if params.has("navigation_layers"):
 			agent.navigation_layers = int(params["navigation_layers"])
 
-		node.add_child(agent, true)
-		agent.owner = get_edited_root()
+		add_child_with_undo(node, agent, root, "MCP: Add NavigationAgent2D")
 
 		return success({
 			"node_path": str(agent.get_path()),
@@ -272,13 +280,13 @@ func _set_navigation_layers(params: Dictionary) -> Dictionary:
 	if params.has("layers"):
 		var layers_val: int = int(params["layers"])
 		if node is NavigationRegion2D:
-			(node as NavigationRegion2D).navigation_layers = layers_val
+			set_property_with_undo(node, "navigation_layers", layers_val, "MCP: Set navigation layers")
 		elif node is NavigationRegion3D:
-			(node as NavigationRegion3D).navigation_layers = layers_val
+			set_property_with_undo(node, "navigation_layers", layers_val, "MCP: Set navigation layers")
 		elif node is NavigationAgent2D:
-			(node as NavigationAgent2D).navigation_layers = layers_val
+			set_property_with_undo(node, "navigation_layers", layers_val, "MCP: Set navigation layers")
 		elif node is NavigationAgent3D:
-			(node as NavigationAgent3D).navigation_layers = layers_val
+			set_property_with_undo(node, "navigation_layers", layers_val, "MCP: Set navigation layers")
 		else:
 			return error_invalid_params("Node '%s' is not a navigation region or agent" % node_path)
 
@@ -300,13 +308,13 @@ func _set_navigation_layers(params: Dictionary) -> Dictionary:
 				current_layers |= (1 << (layer_num - 1))
 
 		if node is NavigationRegion2D:
-			(node as NavigationRegion2D).navigation_layers = current_layers
+			set_property_with_undo(node, "navigation_layers", current_layers, "MCP: Set navigation layers")
 		elif node is NavigationRegion3D:
-			(node as NavigationRegion3D).navigation_layers = current_layers
+			set_property_with_undo(node, "navigation_layers", current_layers, "MCP: Set navigation layers")
 		elif node is NavigationAgent2D:
-			(node as NavigationAgent2D).navigation_layers = current_layers
+			set_property_with_undo(node, "navigation_layers", current_layers, "MCP: Set navigation layers")
 		elif node is NavigationAgent3D:
-			(node as NavigationAgent3D).navigation_layers = current_layers
+			set_property_with_undo(node, "navigation_layers", current_layers, "MCP: Set navigation layers")
 		else:
 			return error_invalid_params("Node '%s' is not a navigation region or agent" % node_path)
 
@@ -332,13 +340,13 @@ func _set_navigation_layers(params: Dictionary) -> Dictionary:
 					current_layers |= (1 << (i - 1))
 
 		if node is NavigationRegion2D:
-			(node as NavigationRegion2D).navigation_layers = current_layers
+			set_property_with_undo(node, "navigation_layers", current_layers, "MCP: Set navigation layers")
 		elif node is NavigationRegion3D:
-			(node as NavigationRegion3D).navigation_layers = current_layers
+			set_property_with_undo(node, "navigation_layers", current_layers, "MCP: Set navigation layers")
 		elif node is NavigationAgent2D:
-			(node as NavigationAgent2D).navigation_layers = current_layers
+			set_property_with_undo(node, "navigation_layers", current_layers, "MCP: Set navigation layers")
 		elif node is NavigationAgent3D:
-			(node as NavigationAgent3D).navigation_layers = current_layers
+			set_property_with_undo(node, "navigation_layers", current_layers, "MCP: Set navigation layers")
 		else:
 			return error_invalid_params("Node '%s' is not a navigation region or agent" % node_path)
 

--- a/addons/godot_mcp/commands/node_commands.gd
+++ b/addons/godot_mcp/commands/node_commands.gd
@@ -355,7 +355,7 @@ func _add_resource(params: Dictionary) -> Dictionary:
 	var resource_props: Dictionary = params.get("resource_properties", {})
 	for prop_name: String in resource_props:
 		if prop_name in resource:
-			var current := resource.get(prop_name)
+			var current: Variant = resource.get(prop_name)
 			resource.set(prop_name, PropertyParser.parse_value(resource_props[prop_name], typeof(current)))
 
 	var old_value: Variant = node.get(property) if property in node else null
@@ -427,17 +427,18 @@ func _set_anchor_preset(params: Dictionary) -> Dictionary:
 	var old_anchors := [control.anchor_left, control.anchor_top, control.anchor_right, control.anchor_bottom]
 	var old_offsets := [control.offset_left, control.offset_top, control.offset_right, control.offset_bottom]
 
-	control.set_anchors_and_offsets_preset(presets[preset_name],
+	var target: Control = control.duplicate() as Control
+	target.set_anchors_and_offsets_preset(presets[preset_name],
 		Control.PRESET_MODE_KEEP_SIZE if keep_offsets else Control.PRESET_MODE_MINSIZE)
 
-	undo_redo.add_do_property(control, "anchor_left", control.anchor_left)
-	undo_redo.add_do_property(control, "anchor_top", control.anchor_top)
-	undo_redo.add_do_property(control, "anchor_right", control.anchor_right)
-	undo_redo.add_do_property(control, "anchor_bottom", control.anchor_bottom)
-	undo_redo.add_do_property(control, "offset_left", control.offset_left)
-	undo_redo.add_do_property(control, "offset_top", control.offset_top)
-	undo_redo.add_do_property(control, "offset_right", control.offset_right)
-	undo_redo.add_do_property(control, "offset_bottom", control.offset_bottom)
+	undo_redo.add_do_property(control, "anchor_left", target.anchor_left)
+	undo_redo.add_do_property(control, "anchor_top", target.anchor_top)
+	undo_redo.add_do_property(control, "anchor_right", target.anchor_right)
+	undo_redo.add_do_property(control, "anchor_bottom", target.anchor_bottom)
+	undo_redo.add_do_property(control, "offset_left", target.offset_left)
+	undo_redo.add_do_property(control, "offset_top", target.offset_top)
+	undo_redo.add_do_property(control, "offset_right", target.offset_right)
+	undo_redo.add_do_property(control, "offset_bottom", target.offset_bottom)
 
 	undo_redo.add_undo_property(control, "anchor_left", old_anchors[0])
 	undo_redo.add_undo_property(control, "anchor_top", old_anchors[1])
@@ -448,6 +449,7 @@ func _set_anchor_preset(params: Dictionary) -> Dictionary:
 	undo_redo.add_undo_property(control, "offset_right", old_offsets[2])
 	undo_redo.add_undo_property(control, "offset_bottom", old_offsets[3])
 
+	target.free()
 	undo_redo.commit_action()
 
 	return success({"node_path": str(root.get_path_to(control)), "preset": preset_name})
@@ -521,7 +523,12 @@ func _connect_signal(params: Dictionary) -> Dictionary:
 	if source.is_connected(signal_name, Callable(target, method_name)):
 		return success({"already_connected": true, "signal": signal_name})
 
-	source.connect(signal_name, Callable(target, method_name))
+	var callable := Callable(target, method_name)
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Connect signal")
+	undo_redo.add_do_method(source, "connect", signal_name, callable)
+	undo_redo.add_undo_method(source, "disconnect", signal_name, callable)
+	undo_redo.commit_action()
 
 	return success({
 		"source": str(root.get_path_to(source)),
@@ -568,7 +575,12 @@ func _disconnect_signal(params: Dictionary) -> Dictionary:
 	if not source.is_connected(signal_name, Callable(target, method_name)):
 		return success({"was_connected": false})
 
-	source.disconnect(signal_name, Callable(target, method_name))
+	var callable := Callable(target, method_name)
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Disconnect signal")
+	undo_redo.add_do_method(source, "disconnect", signal_name, callable)
+	undo_redo.add_undo_method(source, "connect", signal_name, callable)
+	undo_redo.commit_action()
 
 	return success({
 		"source": str(root.get_path_to(source)),
@@ -635,18 +647,25 @@ func _set_node_groups(params: Dictionary) -> Dictionary:
 	var added: Array = []
 	var removed: Array = []
 
-	# Remove groups not in desired
 	for group: String in current_groups:
 		if group not in desired_groups:
-			node.remove_from_group(group)
 			removed.append(group)
 
-	# Add groups not in current
 	for group in desired_groups:
 		var g: String = str(group)
 		if g not in current_groups:
-			node.add_to_group(g, true)
 			added.append(g)
+
+	if not added.is_empty() or not removed.is_empty():
+		var undo_redo := get_undo_redo()
+		undo_redo.create_action("MCP: Set node groups")
+		for group: String in removed:
+			undo_redo.add_do_method(node, "remove_from_group", group)
+			undo_redo.add_undo_method(node, "add_to_group", group, true)
+		for group: String in added:
+			undo_redo.add_do_method(node, "add_to_group", group, true)
+			undo_redo.add_undo_method(node, "remove_from_group", group)
+		undo_redo.commit_action()
 
 	return success({
 		"node_path": str(root.get_path_to(node)),

--- a/addons/godot_mcp/commands/particle_commands.gd
+++ b/addons/godot_mcp/commands/particle_commands.gd
@@ -316,8 +316,8 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 	var is_2d: bool = node is GPUParticles2D
 
 	# Default gravity for 2D (Y-down) vs 3D (Y-down)
-	var gravity_down := Vector3(0, 98 if is_2d else 9.8, 0)
-	var gravity_up := Vector3(0, -98 if is_2d else -9.8, 0)
+	var gravity_down := Vector3(0, 98.0 if is_2d else 9.8, 0)
+	var _gravity_up := Vector3(0, -98.0 if is_2d else -9.8, 0)
 	var gravity_none := Vector3.ZERO
 
 	match preset:

--- a/addons/godot_mcp/commands/particle_commands.gd
+++ b/addons/godot_mcp/commands/particle_commands.gd
@@ -102,8 +102,7 @@ func _create_particles(params: Dictionary) -> Dictionary:
 		p.process_material = mat
 		particles_node = p
 
-	parent.add_child(particles_node, true)
-	particles_node.owner = root
+	add_child_with_undo(parent, particles_node, root, "MCP: Create particles")
 
 	return success({
 		"name": particles_node.name,
@@ -126,10 +125,12 @@ func _set_particle_material(params: Dictionary) -> Dictionary:
 	if node == null:
 		return error_not_found("GPUParticles2D/3D at '%s'" % node_path)
 
-	var mat: ParticleProcessMaterial = node.get("process_material")
-	if mat == null:
+	var old_mat: ParticleProcessMaterial = node.get("process_material")
+	var mat: ParticleProcessMaterial
+	if old_mat != null:
+		mat = old_mat.duplicate(true) as ParticleProcessMaterial
+	else:
 		mat = ParticleProcessMaterial.new()
-		node.set("process_material", mat)
 
 	var changes: Array = []
 
@@ -246,6 +247,8 @@ func _set_particle_material(params: Dictionary) -> Dictionary:
 		mat.attractor_interaction_enabled = bool(params["attractor_interaction_enabled"])
 		changes.append("attractor_interaction_enabled")
 
+	if not changes.is_empty():
+		set_property_with_undo(node, "process_material", mat, "MCP: Set particle material")
 	return success({"node_path": node_path, "changes": changes})
 
 
@@ -259,10 +262,12 @@ func _set_particle_color_gradient(params: Dictionary) -> Dictionary:
 	if node == null:
 		return error_not_found("GPUParticles2D/3D at '%s'" % node_path)
 
-	var mat: ParticleProcessMaterial = node.get("process_material")
-	if mat == null:
+	var old_mat: ParticleProcessMaterial = node.get("process_material")
+	var mat: ParticleProcessMaterial
+	if old_mat != null:
+		mat = old_mat.duplicate(true) as ParticleProcessMaterial
+	else:
 		mat = ParticleProcessMaterial.new()
-		node.set("process_material", mat)
 
 	if not params.has("stops") or not params["stops"] is Array:
 		return error_invalid_params("Missing required parameter: stops (array of {offset, color})")
@@ -285,6 +290,7 @@ func _set_particle_color_gradient(params: Dictionary) -> Dictionary:
 	var grad_tex := GradientTexture1D.new()
 	grad_tex.gradient = gradient
 	mat.color_ramp = grad_tex
+	set_property_with_undo(node, "process_material", mat, "MCP: Set particle color gradient")
 
 	return success({"node_path": node_path, "stops_count": gradient.get_point_count()})
 
@@ -304,6 +310,8 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 	if node == null:
 		return error_not_found("GPUParticles2D/3D at '%s'" % node_path)
 
+	var old_state := _capture_particle_state(node)
+	var preset_state := {}
 	var mat := ParticleProcessMaterial.new()
 	var is_2d: bool = node is GPUParticles2D
 
@@ -314,10 +322,10 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 
 	match preset:
 		"explosion":
-			node.set("amount", 32)
-			node.set("lifetime", 0.6)
-			node.set("one_shot", true)
-			node.set("explosiveness", 1.0)
+			preset_state["amount"] = 32
+			preset_state["lifetime"] = 0.6
+			preset_state["one_shot"] = true
+			preset_state["explosiveness"] = 1.0
 			mat.direction = Vector3(0, -1, 0) if is_2d else Vector3(0, 1, 0)
 			mat.spread = 180.0
 			mat.initial_velocity_min = 100.0 if is_2d else 5.0
@@ -336,10 +344,10 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 			])
 
 		"fire":
-			node.set("amount", 24)
-			node.set("lifetime", 1.2)
-			node.set("one_shot", false)
-			node.set("explosiveness", 0.0)
+			preset_state["amount"] = 24
+			preset_state["lifetime"] = 1.2
+			preset_state["one_shot"] = false
+			preset_state["explosiveness"] = 0.0
 			mat.direction = Vector3(0, -1, 0) if is_2d else Vector3(0, 1, 0)
 			mat.spread = 15.0
 			mat.initial_velocity_min = 30.0 if is_2d else 1.5
@@ -355,10 +363,10 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 			])
 
 		"smoke":
-			node.set("amount", 16)
-			node.set("lifetime", 3.0)
-			node.set("one_shot", false)
-			node.set("explosiveness", 0.0)
+			preset_state["amount"] = 16
+			preset_state["lifetime"] = 3.0
+			preset_state["one_shot"] = false
+			preset_state["explosiveness"] = 0.0
 			mat.direction = Vector3(0, -1, 0) if is_2d else Vector3(0, 1, 0)
 			mat.spread = 25.0
 			mat.initial_velocity_min = 10.0 if is_2d else 0.5
@@ -375,10 +383,10 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 			])
 
 		"sparks":
-			node.set("amount", 48)
-			node.set("lifetime", 0.4)
-			node.set("one_shot", true)
-			node.set("explosiveness", 0.95)
+			preset_state["amount"] = 48
+			preset_state["lifetime"] = 0.4
+			preset_state["one_shot"] = true
+			preset_state["explosiveness"] = 0.95
 			mat.direction = Vector3(0, -1, 0) if is_2d else Vector3(0, 1, 0)
 			mat.spread = 180.0
 			mat.initial_velocity_min = 200.0 if is_2d else 8.0
@@ -395,10 +403,10 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 			])
 
 		"rain":
-			node.set("amount", 64)
-			node.set("lifetime", 0.8)
-			node.set("one_shot", false)
-			node.set("explosiveness", 0.0)
+			preset_state["amount"] = 64
+			preset_state["lifetime"] = 0.8
+			preset_state["one_shot"] = false
+			preset_state["explosiveness"] = 0.0
 			mat.direction = Vector3(0, 1, 0) if is_2d else Vector3(0, -1, 0)
 			mat.spread = 5.0
 			mat.initial_velocity_min = 300.0 if is_2d else 12.0
@@ -411,10 +419,10 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 			mat.color = Color(0.6, 0.7, 1.0, 0.7)
 
 		"snow":
-			node.set("amount", 48)
-			node.set("lifetime", 4.0)
-			node.set("one_shot", false)
-			node.set("explosiveness", 0.0)
+			preset_state["amount"] = 48
+			preset_state["lifetime"] = 4.0
+			preset_state["one_shot"] = false
+			preset_state["explosiveness"] = 0.0
 			mat.direction = Vector3(0, 1, 0) if is_2d else Vector3(0, -1, 0)
 			mat.spread = 20.0
 			mat.initial_velocity_min = 20.0 if is_2d else 0.8
@@ -431,10 +439,10 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 			mat.color = Color(1.0, 1.0, 1.0, 0.9)
 
 		"magic":
-			node.set("amount", 24)
-			node.set("lifetime", 2.0)
-			node.set("one_shot", false)
-			node.set("explosiveness", 0.0)
+			preset_state["amount"] = 24
+			preset_state["lifetime"] = 2.0
+			preset_state["one_shot"] = false
+			preset_state["explosiveness"] = 0.0
 			mat.direction = Vector3(0, -1, 0) if is_2d else Vector3(0, 1, 0)
 			mat.spread = 180.0
 			mat.initial_velocity_min = 20.0 if is_2d else 1.0
@@ -455,10 +463,10 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 			])
 
 		"dust":
-			node.set("amount", 12)
-			node.set("lifetime", 5.0)
-			node.set("one_shot", false)
-			node.set("explosiveness", 0.0)
+			preset_state["amount"] = 12
+			preset_state["lifetime"] = 5.0
+			preset_state["one_shot"] = false
+			preset_state["explosiveness"] = 0.0
 			mat.direction = Vector3(0, -1, 0) if is_2d else Vector3(0, 1, 0)
 			mat.spread = 180.0
 			mat.initial_velocity_min = 3.0 if is_2d else 0.1
@@ -480,9 +488,31 @@ func _apply_particle_preset(params: Dictionary) -> Dictionary:
 		_:
 			return error_invalid_params("Unknown preset: '%s'. Valid presets: explosion, fire, smoke, sparks, rain, snow, magic, dust" % preset)
 
-	node.set("process_material", mat)
+	preset_state["process_material"] = mat
+	_register_particle_state_undo(node, old_state, preset_state, "MCP: Apply particle preset")
 
 	return success({"node_path": node_path, "preset": preset, "applied": true})
+
+
+func _capture_particle_state(node: Node) -> Dictionary:
+	var state := {}
+	for property: String in ["amount", "lifetime", "one_shot", "explosiveness", "randomness", "emitting", "process_material"]:
+		if property in node:
+			state[property] = node.get(property)
+	return state
+
+
+func _register_particle_state_undo(node: Node, old_state: Dictionary, new_state: Dictionary, action_name: String) -> void:
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action(action_name)
+	for property: String in new_state:
+		undo_redo.add_do_property(node, property, new_state[property])
+		if new_state[property] is Resource:
+			undo_redo.add_do_reference(new_state[property])
+		undo_redo.add_undo_property(node, property, old_state.get(property, null))
+		if old_state.get(property, null) is Resource:
+			undo_redo.add_undo_reference(old_state[property])
+	undo_redo.commit_action()
 
 
 func _apply_gradient(mat: ParticleProcessMaterial, stops: Array) -> void:

--- a/addons/godot_mcp/commands/resource_commands.gd
+++ b/addons/godot_mcp/commands/resource_commands.gd
@@ -22,6 +22,10 @@ func _read_resource(params: Dictionary) -> Dictionary:
 	if not FileAccess.file_exists(path):
 		return error_not_found("Resource '%s'" % path)
 
+	var guard := guard_offline_scene_save(path)
+	if not guard.is_empty():
+		return guard
+
 	var resource: Resource = ResourceLoader.load(path)
 	if resource == null:
 		return error_internal("Failed to load resource: %s" % path)
@@ -107,6 +111,10 @@ func _create_resource(params: Dictionary) -> Dictionary:
 	var overwrite: bool = optional_bool(params, "overwrite", false)
 	if FileAccess.file_exists(path) and not overwrite:
 		return error(-32000, "Resource already exists: %s" % path, {"suggestion": "Set overwrite=true to replace"})
+
+	var guard := guard_offline_scene_save(path)
+	if not guard.is_empty():
+		return guard
 
 	var resource: Resource = ClassDB.instantiate(resource_type)
 	if resource == null:

--- a/addons/godot_mcp/commands/resource_commands.gd
+++ b/addons/godot_mcp/commands/resource_commands.gd
@@ -61,6 +61,10 @@ func _edit_resource(params: Dictionary) -> Dictionary:
 	if not FileAccess.file_exists(path):
 		return error_not_found("Resource '%s'" % path)
 
+	var guard := guard_offline_scene_save(path)
+	if not guard.is_empty():
+		return guard
+
 	var resource: Resource = ResourceLoader.load(path)
 	if resource == null:
 		return error_internal("Failed to load resource: %s" % path)

--- a/addons/godot_mcp/commands/resource_commands.gd
+++ b/addons/godot_mcp/commands/resource_commands.gd
@@ -124,7 +124,7 @@ func _create_resource(params: Dictionary) -> Dictionary:
 	var properties: Dictionary = params.get("properties", {})
 	for prop_name: String in properties:
 		if prop_name in resource:
-			var current := resource.get(prop_name)
+			var current: Variant = resource.get(prop_name)
 			resource.set(prop_name, PropertyParser.parse_value(properties[prop_name], typeof(current)))
 
 	var err := ResourceSaver.save(resource, path)
@@ -132,7 +132,7 @@ func _create_resource(params: Dictionary) -> Dictionary:
 		return error_internal("Failed to save resource: %s" % error_string(err))
 
 	# Rescan filesystem
-	get_editor().get_resource_filesystem().scan()
+	EditorInterface.get_resource_filesystem().scan()
 
 	return success({
 		"path": path,

--- a/addons/godot_mcp/commands/scene_commands.gd
+++ b/addons/godot_mcp/commands/scene_commands.gd
@@ -54,6 +54,10 @@ func _create_scene(params: Dictionary) -> Dictionary:
 		return result[1]
 	var path: String = result[0]
 
+	var guard := guard_offline_scene_save(path)
+	if not guard.is_empty():
+		return guard
+
 	var root_type: String = optional_string(params, "root_type", "Node2D")
 	var root_name: String = optional_string(params, "root_name", "")
 
@@ -214,16 +218,35 @@ func _save_scene(params: Dictionary) -> Dictionary:
 	if path.is_empty():
 		return error_invalid_params("No save path specified and scene has no existing path")
 
-	var scene := PackedScene.new()
-	var err := scene.pack(root)
-	if err != OK:
-		return error_internal("Failed to pack scene: %s" % error_string(err))
+	var normalized_path := normalize_project_path(path)
+	if is_scene_path_open(normalized_path) and not is_active_scene_path(normalized_path):
+		return error_conflict(
+			"Refusing to save inactive open scene '%s' from the active editor scene" % normalized_path,
+			{
+				"path": normalized_path,
+				"active_scene": normalize_project_path(root.scene_file_path),
+				"open_scenes": get_open_scene_paths(),
+				"suggestion": "Open the target scene tab before saving it, or close it before offline edits.",
+			}
+		)
 
-	err = ResourceSaver.save(scene, path)
-	if err != OK:
-		return error_internal("Failed to save scene: %s" % error_string(err))
+	var dir_path := normalized_path.get_base_dir()
+	if not DirAccess.dir_exists_absolute(dir_path):
+		DirAccess.make_dir_recursive_absolute(dir_path)
 
-	return success({"path": path, "saved": true})
+	var err: int
+	var save_method: String
+	if root.scene_file_path.is_empty() or normalize_project_path(root.scene_file_path) != normalized_path:
+		get_editor().save_scene_as(normalized_path)
+		err = OK
+		save_method = "EditorInterface.save_scene_as"
+	else:
+		err = get_editor().save_scene()
+		save_method = "EditorInterface.save_scene"
+	if err != OK:
+		return error_internal("Failed to save scene via %s: %s" % [save_method, error_string(err)])
+
+	return success({"path": normalized_path, "saved": true, "method": save_method})
 
 
 func _get_scene_exports(params: Dictionary) -> Dictionary:

--- a/addons/godot_mcp/commands/scene_commands.gd
+++ b/addons/godot_mcp/commands/scene_commands.gd
@@ -88,7 +88,7 @@ func _create_scene(params: Dictionary) -> Dictionary:
 		return error_internal("Failed to save scene: %s" % error_string(err))
 
 	# Refresh filesystem
-	get_editor().get_resource_filesystem().scan()
+	EditorInterface.get_resource_filesystem().scan()
 
 	return success({"path": path, "root_type": root_type, "root_name": root_name})
 
@@ -102,7 +102,7 @@ func _open_scene(params: Dictionary) -> Dictionary:
 	if not FileAccess.file_exists(path):
 		return error_not_found("Scene file '%s'" % path)
 
-	get_editor().open_scene_from_path(path)
+	EditorInterface.open_scene_from_path(path)
 	return success({"path": path, "opened": true})
 
 
@@ -124,7 +124,7 @@ func _delete_scene(params: Dictionary) -> Dictionary:
 	if FileAccess.file_exists(import_path):
 		DirAccess.remove_absolute(import_path)
 
-	get_editor().get_resource_filesystem().scan()
+	EditorInterface.get_resource_filesystem().scan()
 	return success({"path": path, "deleted": true})
 
 
@@ -175,28 +175,26 @@ func _add_scene_instance(params: Dictionary) -> Dictionary:
 
 func _play_scene(params: Dictionary) -> Dictionary:
 	var mode: String = optional_string(params, "mode", "main")  # "main", "current", or path
-	var ei := get_editor()
 
 	match mode:
 		"main":
-			ei.play_main_scene()
+			EditorInterface.play_main_scene()
 		"current":
-			ei.play_current_scene()
+			EditorInterface.play_current_scene()
 		_:
 			# Treat as scene path
 			if not FileAccess.file_exists(mode):
 				return error_not_found("Scene file '%s'" % mode)
-			ei.play_custom_scene(mode)
+			EditorInterface.play_custom_scene(mode)
 
 	return success({"playing": true, "mode": mode})
 
 
-func _stop_scene(params: Dictionary) -> Dictionary:
-	var ei := get_editor()
-	if not ei.is_playing_scene():
+func _stop_scene(_params: Dictionary) -> Dictionary:
+	if not EditorInterface.is_playing_scene():
 		return success({"stopped": false, "message": "No scene is currently playing"})
 
-	ei.stop_playing_scene()
+	EditorInterface.stop_playing_scene()
 
 	# Clean up temp files
 	_cleanup_screenshot_files()
@@ -237,11 +235,11 @@ func _save_scene(params: Dictionary) -> Dictionary:
 	var err: int
 	var save_method: String
 	if root.scene_file_path.is_empty() or normalize_project_path(root.scene_file_path) != normalized_path:
-		get_editor().save_scene_as(normalized_path)
+		EditorInterface.save_scene_as(normalized_path)
 		err = OK
 		save_method = "EditorInterface.save_scene_as"
 	else:
-		err = get_editor().save_scene()
+		err = EditorInterface.save_scene()
 		save_method = "EditorInterface.save_scene"
 	if err != OK:
 		return error_internal("Failed to save scene via %s: %s" % [save_method, error_string(err)])

--- a/addons/godot_mcp/commands/script_commands.gd
+++ b/addons/godot_mcp/commands/script_commands.gd
@@ -160,7 +160,6 @@ func _edit_script(params: Dictionary) -> Dictionary:
 	var content := file.get_as_text()
 	file.close()
 
-	var old_content := content
 	var changes_made := 0
 
 	# Support search-and-replace
@@ -184,6 +183,32 @@ func _edit_script(params: Dictionary) -> Dictionary:
 						if content.contains(search):
 							content = content.replace(search, replace)
 							changes_made += 1
+
+	# Support 1-based inclusive line range replacement
+	elif params.has("content") and (params.has("start_line") or params.has("end_line")):
+		if not params.has("start_line"):
+			return error_invalid_params("start_line is required when end_line is provided")
+		var start_line: int = int(params["start_line"])
+		var end_line: int = int(params.get("end_line", start_line))
+		var lines := content.split("\n")
+		if start_line < 1:
+			return error_invalid_params("start_line must be >= 1")
+		if end_line < start_line:
+			return error_invalid_params("end_line must be >= start_line")
+		if start_line > lines.size():
+			return error_invalid_params("start_line is beyond the end of the file")
+		if end_line > lines.size():
+			return error_invalid_params("end_line is beyond the end of the file")
+
+		var replacement_lines := str(params["content"]).split("\n")
+		var start_index := start_line - 1
+		var remove_count := end_line - start_line + 1
+		for _i in range(remove_count):
+			lines.remove_at(start_index)
+		for i in range(replacement_lines.size()):
+			lines.insert(start_index + i, replacement_lines[i])
+		content = "\n".join(lines)
+		changes_made = 1
 
 	# Support full content replacement
 	elif params.has("content"):

--- a/addons/godot_mcp/commands/script_commands.gd
+++ b/addons/godot_mcp/commands/script_commands.gd
@@ -14,6 +14,21 @@ func get_commands() -> Dictionary:
 	}
 
 
+func _guard_script_file_path(path: String, operation: String) -> Dictionary:
+	var ext := path.get_extension().to_lower()
+	if ext in ["gd", "cs"]:
+		return {}
+	return error(
+		-32602,
+		"%s only supports script files (.gd, .cs): %s" % [operation, normalize_project_path(path)],
+		{
+			"path": normalize_project_path(path),
+			"extension": ext,
+			"suggestion": "Use scene commands for .tscn/.scn files and shader commands for shader resources.",
+		}
+	)
+
+
 func _list_scripts(params: Dictionary) -> Dictionary:
 	var path: String = optional_string(params, "path", "res://")
 	var recursive: bool = optional_bool(params, "recursive", true)
@@ -92,6 +107,9 @@ func _create_script(params: Dictionary) -> Dictionary:
 	if result[1] != null:
 		return result[1]
 	var path: String = result[0]
+	var path_guard := _guard_script_file_path(path, "create_script")
+	if not path_guard.is_empty():
+		return path_guard
 
 	var content: String = optional_string(params, "content", "")
 	var base_class: String = optional_string(params, "extends", "Node")
@@ -143,6 +161,9 @@ func _edit_script(params: Dictionary) -> Dictionary:
 	if result[1] != null:
 		return result[1]
 	var path: String = result[0]
+	var path_guard := _guard_script_file_path(path, "edit_script")
+	if not path_guard.is_empty():
+		return path_guard
 
 	if not FileAccess.file_exists(path):
 		return error_not_found("Script '%s'" % path)
@@ -304,6 +325,9 @@ func _validate_script(params: Dictionary) -> Dictionary:
 	if result[1] != null:
 		return result[1]
 	var path: String = result[0]
+	var path_guard := _guard_script_file_path(path, "validate_script")
+	if not path_guard.is_empty():
+		return path_guard
 
 	if not FileAccess.file_exists(path):
 		return error_not_found("Script '%s'" % path)

--- a/addons/godot_mcp/commands/script_commands.gd
+++ b/addons/godot_mcp/commands/script_commands.gd
@@ -127,7 +127,7 @@ func _create_script(params: Dictionary) -> Dictionary:
 	file.store_string(content)
 	file.close()
 
-	get_editor().get_resource_filesystem().scan()
+	EditorInterface.get_resource_filesystem().scan()
 
 	# Pre-load so the script is available immediately
 	if ResourceLoader.exists(path):
@@ -245,7 +245,7 @@ func _edit_script(params: Dictionary) -> Dictionary:
 ## Force-reload a script so the editor reflects disk changes immediately.
 func _reload_script(path: String) -> void:
 	# First, trigger a filesystem scan so Godot knows the file changed
-	get_editor().get_resource_filesystem().scan()
+	EditorInterface.get_resource_filesystem().scan()
 
 	# If the script is already loaded in memory, reload it
 	if ResourceLoader.exists(path):
@@ -255,7 +255,7 @@ func _reload_script(path: String) -> void:
 
 	# If the script is open in the script editor, the reload above updates it.
 	# But we also need to notify the editor to refresh its error indicators.
-	get_editor().get_script_editor().notification(Control.NOTIFICATION_VISIBILITY_CHANGED)
+	EditorInterface.get_script_editor().notification(Control.NOTIFICATION_VISIBILITY_CHANGED)
 
 
 func _attach_script(params: Dictionary) -> Dictionary:
@@ -331,8 +331,8 @@ func _validate_script(params: Dictionary) -> Dictionary:
 	})
 
 
-func _get_open_scripts(params: Dictionary) -> Dictionary:
-	var script_editor := get_editor().get_script_editor()
+func _get_open_scripts(_params: Dictionary) -> Dictionary:
+	var script_editor := EditorInterface.get_script_editor()
 	var open_scripts: Array = []
 
 	for script_base in script_editor.get_open_scripts():

--- a/addons/godot_mcp/commands/script_commands.gd
+++ b/addons/godot_mcp/commands/script_commands.gd
@@ -96,6 +96,11 @@ func _create_script(params: Dictionary) -> Dictionary:
 	var content: String = optional_string(params, "content", "")
 	var base_class: String = optional_string(params, "extends", "Node")
 	var class_name_str: String = optional_string(params, "class_name", "")
+	var force: bool = optional_bool(params, "force", false)
+
+	var guard := guard_text_resource_write(path, force)
+	if not guard.is_empty():
+		return guard
 
 	# Generate template if no content provided
 	if content.is_empty():
@@ -141,6 +146,11 @@ func _edit_script(params: Dictionary) -> Dictionary:
 
 	if not FileAccess.file_exists(path):
 		return error_not_found("Script '%s'" % path)
+
+	var force: bool = optional_bool(params, "force", false)
+	var guard := guard_text_resource_write(path, force)
+	if not guard.is_empty():
+		return guard
 
 	# Read current content
 	var file := FileAccess.open(path, FileAccess.READ)

--- a/addons/godot_mcp/commands/shader_commands.gd
+++ b/addons/godot_mcp/commands/shader_commands.gd
@@ -74,6 +74,16 @@ func _read_shader(params: Dictionary) -> Dictionary:
 	return success({"path": path, "content": content, "size": content.length()})
 
 
+func _refresh_loaded_shader(path: String, content: String) -> void:
+	get_editor().get_resource_filesystem().scan()
+	var normalized := normalize_project_path(path)
+	if normalized.is_empty() or not ResourceLoader.has_cached(normalized):
+		return
+	var shader_resource := ResourceLoader.load(normalized, "Shader")
+	if shader_resource is Shader:
+		(shader_resource as Shader).code = content
+
+
 func _edit_shader(params: Dictionary) -> Dictionary:
 	var result := require_string(params, "path")
 	if result[1] != null:
@@ -89,21 +99,17 @@ func _edit_shader(params: Dictionary) -> Dictionary:
 		return guard
 
 	var changes_made := 0
+	var content := ""
 
 	if params.has("content"):
-		# Full replacement
-		var file := FileAccess.open(path, FileAccess.WRITE)
-		if file == null:
-			return error_internal("Cannot write shader")
-		file.store_string(str(params["content"]))
-		file.close()
+		content = str(params["content"])
 		changes_made = 1
 	elif params.has("replacements") and params["replacements"] is Array:
 		# Read current
 		var file := FileAccess.open(path, FileAccess.READ)
 		if file == null:
 			return error_internal("Cannot read shader")
-		var content := file.get_as_text()
+		content = file.get_as_text()
 		file.close()
 
 		for replacement in params["replacements"]:
@@ -114,18 +120,13 @@ func _edit_shader(params: Dictionary) -> Dictionary:
 					content = content.replace(search, replace)
 					changes_made += 1
 
-		file = FileAccess.open(path, FileAccess.WRITE)
-		if file:
-			file.store_string(content)
-			file.close()
-
 	if changes_made > 0:
-		# Reload shader resource
-		get_editor().get_resource_filesystem().scan()
-		if ResourceLoader.exists(path):
-			var shader = load(path)
-			if shader is Shader:
-				shader.reload_from_file()
+		var file := FileAccess.open(path, FileAccess.WRITE)
+		if file == null:
+			return error_internal("Cannot write shader: %s" % error_string(FileAccess.get_open_error()))
+		file.store_string(content)
+		file.close()
+		_refresh_loaded_shader(path, content)
 
 	return success({"path": path, "changes_made": changes_made})
 

--- a/addons/godot_mcp/commands/shader_commands.gd
+++ b/addons/godot_mcp/commands/shader_commands.gd
@@ -50,7 +50,7 @@ func _create_shader(params: Dictionary) -> Dictionary:
 	file.store_string(content)
 	file.close()
 
-	get_editor().get_resource_filesystem().scan()
+	EditorInterface.get_resource_filesystem().scan()
 
 	return success({"path": path, "shader_type": shader_type, "created": true})
 
@@ -75,7 +75,7 @@ func _read_shader(params: Dictionary) -> Dictionary:
 
 
 func _refresh_loaded_shader(path: String, content: String) -> void:
-	get_editor().get_resource_filesystem().scan()
+	EditorInterface.get_resource_filesystem().scan()
 	var normalized := normalize_project_path(path)
 	if normalized.is_empty() or not ResourceLoader.has_cached(normalized):
 		return

--- a/addons/godot_mcp/commands/shader_commands.gd
+++ b/addons/godot_mcp/commands/shader_commands.gd
@@ -50,7 +50,7 @@ func _create_shader(params: Dictionary) -> Dictionary:
 	file.store_string(content)
 	file.close()
 
-	EditorInterface.get_resource_filesystem().scan()
+	_refresh_loaded_shader(path, content)
 
 	return success({"path": path, "shader_type": shader_type, "created": true})
 
@@ -75,13 +75,15 @@ func _read_shader(params: Dictionary) -> Dictionary:
 
 
 func _refresh_loaded_shader(path: String, content: String) -> void:
-	EditorInterface.get_resource_filesystem().scan()
 	var normalized := normalize_project_path(path)
-	if normalized.is_empty() or not ResourceLoader.has_cached(normalized):
+	if normalized.is_empty():
 		return
-	var shader_resource := ResourceLoader.load(normalized, "Shader")
-	if shader_resource is Shader:
-		(shader_resource as Shader).code = content
+	if ResourceLoader.has_cached(normalized):
+		var shader := Shader.new()
+		shader.code = content
+		shader.take_over_path(normalized)
+		shader.emit_changed()
+	EditorInterface.get_resource_filesystem().update_file(normalized)
 
 
 func _edit_shader(params: Dictionary) -> Dictionary:

--- a/addons/godot_mcp/commands/shader_commands.gd
+++ b/addons/godot_mcp/commands/shader_commands.gd
@@ -21,6 +21,11 @@ func _create_shader(params: Dictionary) -> Dictionary:
 
 	var content: String = optional_string(params, "content", "")
 	var shader_type: String = optional_string(params, "shader_type", "spatial")
+	var force: bool = optional_bool(params, "force", false)
+
+	var guard := guard_text_resource_write(path, force)
+	if not guard.is_empty():
+		return guard
 
 	if content.is_empty():
 		match shader_type:
@@ -77,6 +82,11 @@ func _edit_shader(params: Dictionary) -> Dictionary:
 
 	if not FileAccess.file_exists(path):
 		return error_not_found("Shader '%s'" % path)
+
+	var force: bool = optional_bool(params, "force", false)
+	var guard := guard_text_resource_write(path, force)
+	if not guard.is_empty():
+		return guard
 
 	var changes_made := 0
 
@@ -146,13 +156,13 @@ func _assign_shader_material(params: Dictionary) -> Dictionary:
 	material.shader = shader
 
 	if node is CanvasItem:
-		(node as CanvasItem).material = material
+		set_property_with_undo(node, "material", material, "MCP: Assign shader material")
 	elif node is MeshInstance3D:
-		(node as MeshInstance3D).material_override = material
+		set_property_with_undo(node, "material_override", material, "MCP: Assign shader material")
 	else:
 		# Try generic material property
 		if "material" in node:
-			node.set("material", material)
+			set_property_with_undo(node, "material", material, "MCP: Assign shader material")
 		else:
 			return error_invalid_params("Node '%s' (%s) does not support materials" % [node_path, node.get_class()])
 

--- a/addons/godot_mcp/commands/theme_commands.gd
+++ b/addons/godot_mcp/commands/theme_commands.gd
@@ -35,7 +35,7 @@ func _create_theme(params: Dictionary) -> Dictionary:
 	if err != OK:
 		return error_internal("Failed to save theme: %s" % error_string(err))
 
-	get_editor().get_resource_filesystem().scan()
+	EditorInterface.get_resource_filesystem().scan()
 	return success({"path": path, "created": true})
 
 
@@ -327,28 +327,28 @@ func _setup_control(params: Dictionary) -> Dictionary:
 	return success({"node_path": node_path, "applied": applied, "count": applied.size()})
 
 
-func _restore_theme_override(control: Control, kind: String, name: String, had_old: bool, old_value: Variant) -> void:
+func _restore_theme_override(control: Control, kind: String, override_name: String, had_old: bool, old_value: Variant) -> void:
 	match kind:
 		"color":
 			if had_old:
-				control.add_theme_color_override(name, old_value)
+				control.add_theme_color_override(override_name, old_value)
 			else:
-				control.remove_theme_color_override(name)
+				control.remove_theme_color_override(override_name)
 		"constant":
 			if had_old:
-				control.add_theme_constant_override(name, old_value)
+				control.add_theme_constant_override(override_name, old_value)
 			else:
-				control.remove_theme_constant_override(name)
+				control.remove_theme_constant_override(override_name)
 		"font_size":
 			if had_old:
-				control.add_theme_font_size_override(name, old_value)
+				control.add_theme_font_size_override(override_name, old_value)
 			else:
-				control.remove_theme_font_size_override(name)
+				control.remove_theme_font_size_override(override_name)
 		"stylebox":
 			if had_old:
-				control.add_theme_stylebox_override(name, old_value)
+				control.add_theme_stylebox_override(override_name, old_value)
 			else:
-				control.remove_theme_stylebox_override(name)
+				control.remove_theme_stylebox_override(override_name)
 
 
 func _capture_control_setup_state(control: Control) -> Dictionary:

--- a/addons/godot_mcp/commands/theme_commands.gd
+++ b/addons/godot_mcp/commands/theme_commands.gd
@@ -27,6 +27,10 @@ func _create_theme(params: Dictionary) -> Dictionary:
 	if font_size > 0:
 		theme.default_font_size = font_size
 
+	var scene_guard := guard_offline_scene_save(path)
+	if scene_guard != null:
+		return scene_guard
+
 	var err := ResourceSaver.save(theme, path)
 	if err != OK:
 		return error_internal("Failed to save theme: %s" % error_string(err))
@@ -62,7 +66,13 @@ func _set_theme_color(params: Dictionary) -> Dictionary:
 	if theme_type.is_empty():
 		theme_type = control.get_class()
 
-	control.add_theme_color_override(color_name, color)
+	var had_old := control.has_theme_color_override(color_name)
+	var old_value: Variant = control.get("theme_override_colors/" + color_name) if had_old else null
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Set theme color override")
+	undo_redo.add_do_method(control, "add_theme_color_override", color_name, color)
+	undo_redo.add_undo_method(self, "_restore_theme_override", control, "color", color_name, had_old, old_value)
+	undo_redo.commit_action()
 
 	return success({"node_path": node_path, "name": color_name, "color": color_str})
 
@@ -85,7 +95,13 @@ func _set_theme_constant(params: Dictionary) -> Dictionary:
 	var control: Control = node
 	var value: int = int(params.get("value", 0))
 
-	control.add_theme_constant_override(const_name, value)
+	var had_old := control.has_theme_constant_override(const_name)
+	var old_value: Variant = control.get("theme_override_constants/" + const_name) if had_old else null
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Set theme constant override")
+	undo_redo.add_do_method(control, "add_theme_constant_override", const_name, value)
+	undo_redo.add_undo_method(self, "_restore_theme_override", control, "constant", const_name, had_old, old_value)
+	undo_redo.commit_action()
 
 	return success({"node_path": node_path, "name": const_name, "value": value})
 
@@ -108,7 +124,13 @@ func _set_theme_font_size(params: Dictionary) -> Dictionary:
 	var control: Control = node
 	var size: int = int(params.get("size", 16))
 
-	control.add_theme_font_size_override(font_name, size)
+	var had_old := control.has_theme_font_size_override(font_name)
+	var old_value: Variant = control.get("theme_override_font_sizes/" + font_name) if had_old else null
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Set theme font size override")
+	undo_redo.add_do_method(control, "add_theme_font_size_override", font_name, size)
+	undo_redo.add_undo_method(self, "_restore_theme_override", control, "font_size", font_name, had_old, old_value)
+	undo_redo.commit_action()
 
 	return success({"node_path": node_path, "name": font_name, "size": size})
 
@@ -161,7 +183,16 @@ func _set_theme_stylebox(params: Dictionary) -> Dictionary:
 		stylebox.content_margin_right = padding
 		stylebox.content_margin_bottom = padding
 
-	control.add_theme_stylebox_override(style_name, stylebox)
+	var had_old := control.has_theme_stylebox_override(style_name)
+	var old_value: Variant = control.get("theme_override_styles/" + style_name) if had_old else null
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Set theme stylebox override")
+	undo_redo.add_do_method(control, "add_theme_stylebox_override", style_name, stylebox)
+	undo_redo.add_do_reference(stylebox)
+	undo_redo.add_undo_method(self, "_restore_theme_override", control, "stylebox", style_name, had_old, old_value)
+	if old_value is Resource:
+		undo_redo.add_undo_reference(old_value)
+	undo_redo.commit_action()
 
 	return success({"node_path": node_path, "name": style_name, "type": "StyleBoxFlat"})
 
@@ -178,6 +209,8 @@ func _setup_control(params: Dictionary) -> Dictionary:
 
 	var control: Control = node
 	var applied: Array = []
+	var old_state := _capture_control_setup_state(control)
+	var target: Control = control.duplicate() as Control
 
 	# Anchor preset
 	var anchor_preset: String = optional_string(params, "anchor_preset", "")
@@ -201,7 +234,7 @@ func _setup_control(params: Dictionary) -> Dictionary:
 			"full_rect": Control.PRESET_FULL_RECT,
 		}
 		if preset_map.has(anchor_preset):
-			control.set_anchors_and_offsets_preset(preset_map[anchor_preset])
+			target.set_anchors_and_offsets_preset(preset_map[anchor_preset])
 			applied.append("anchor_preset=%s" % anchor_preset)
 
 	# Min size
@@ -211,7 +244,7 @@ func _setup_control(params: Dictionary) -> Dictionary:
 		if expr.parse(min_size_str) == OK:
 			var val = expr.execute()
 			if val is Vector2:
-				control.custom_minimum_size = val
+				target.custom_minimum_size = val
 				applied.append("min_size=%s" % min_size_str)
 
 	# Size flags horizontal
@@ -225,7 +258,7 @@ func _setup_control(params: Dictionary) -> Dictionary:
 			"shrink_end": Control.SIZE_SHRINK_END,
 		}
 		if flags_map.has(sf_h):
-			control.size_flags_horizontal = flags_map[sf_h]
+			target.size_flags_horizontal = flags_map[sf_h]
 			applied.append("size_flags_h=%s" % sf_h)
 
 	# Size flags vertical
@@ -239,28 +272,28 @@ func _setup_control(params: Dictionary) -> Dictionary:
 			"shrink_end": Control.SIZE_SHRINK_END,
 		}
 		if flags_map.has(sf_v):
-			control.size_flags_vertical = flags_map[sf_v]
+			target.size_flags_vertical = flags_map[sf_v]
 			applied.append("size_flags_v=%s" % sf_v)
 
 	# Margins (for MarginContainer)
 	if params.has("margins") and params["margins"] is Dictionary:
 		var margins: Dictionary = params["margins"]
-		if control is MarginContainer:
+		if target is MarginContainer:
 			if margins.has("left"):
-				control.add_theme_constant_override("margin_left", int(margins["left"]))
+				target.add_theme_constant_override("margin_left", int(margins["left"]))
 			if margins.has("top"):
-				control.add_theme_constant_override("margin_top", int(margins["top"]))
+				target.add_theme_constant_override("margin_top", int(margins["top"]))
 			if margins.has("right"):
-				control.add_theme_constant_override("margin_right", int(margins["right"]))
+				target.add_theme_constant_override("margin_right", int(margins["right"]))
 			if margins.has("bottom"):
-				control.add_theme_constant_override("margin_bottom", int(margins["bottom"]))
+				target.add_theme_constant_override("margin_bottom", int(margins["bottom"]))
 			applied.append("margins=%s" % str(margins))
 
 	# Separation (for VBox/HBoxContainer)
 	if params.has("separation"):
 		var sep: int = int(params["separation"])
-		if control is BoxContainer:
-			control.add_theme_constant_override("separation", sep)
+		if target is BoxContainer:
+			target.add_theme_constant_override("separation", sep)
 			applied.append("separation=%d" % sep)
 
 	# Grow direction horizontal
@@ -272,7 +305,7 @@ func _setup_control(params: Dictionary) -> Dictionary:
 			"both": Control.GROW_DIRECTION_BOTH,
 		}
 		if grow_map.has(grow_h):
-			control.grow_horizontal = grow_map[grow_h]
+			target.grow_horizontal = grow_map[grow_h]
 			applied.append("grow_h=%s" % grow_h)
 
 	# Grow direction vertical
@@ -284,10 +317,70 @@ func _setup_control(params: Dictionary) -> Dictionary:
 			"both": Control.GROW_DIRECTION_BOTH,
 		}
 		if grow_map.has(grow_v):
-			control.grow_vertical = grow_map[grow_v]
+			target.grow_vertical = grow_map[grow_v]
 			applied.append("grow_v=%s" % grow_v)
 
+	if not applied.is_empty():
+		var new_state := _capture_control_setup_state(target)
+		_register_control_setup_undo(control, old_state, new_state)
+	target.free()
 	return success({"node_path": node_path, "applied": applied, "count": applied.size()})
+
+
+func _restore_theme_override(control: Control, kind: String, name: String, had_old: bool, old_value: Variant) -> void:
+	match kind:
+		"color":
+			if had_old:
+				control.add_theme_color_override(name, old_value)
+			else:
+				control.remove_theme_color_override(name)
+		"constant":
+			if had_old:
+				control.add_theme_constant_override(name, old_value)
+			else:
+				control.remove_theme_constant_override(name)
+		"font_size":
+			if had_old:
+				control.add_theme_font_size_override(name, old_value)
+			else:
+				control.remove_theme_font_size_override(name)
+		"stylebox":
+			if had_old:
+				control.add_theme_stylebox_override(name, old_value)
+			else:
+				control.remove_theme_stylebox_override(name)
+
+
+func _capture_control_setup_state(control: Control) -> Dictionary:
+	var state := {"properties": {}, "theme_constants": {}}
+	for property: String in [
+		"anchor_left", "anchor_top", "anchor_right", "anchor_bottom",
+		"offset_left", "offset_top", "offset_right", "offset_bottom",
+		"custom_minimum_size", "size_flags_horizontal", "size_flags_vertical",
+		"grow_horizontal", "grow_vertical",
+	]:
+		state["properties"][property] = control.get(property)
+	for constant_name: String in ["margin_left", "margin_top", "margin_right", "margin_bottom", "separation"]:
+		var had_override := control.has_theme_constant_override(constant_name)
+		state["theme_constants"][constant_name] = {
+			"had": had_override,
+			"value": control.get("theme_override_constants/" + constant_name) if had_override else null,
+		}
+	return state
+
+
+func _register_control_setup_undo(control: Control, old_state: Dictionary, new_state: Dictionary) -> void:
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Setup Control")
+	for property: String in new_state["properties"]:
+		undo_redo.add_do_property(control, property, new_state["properties"][property])
+		undo_redo.add_undo_property(control, property, old_state["properties"][property])
+	for constant_name: String in new_state["theme_constants"]:
+		var new_constant: Dictionary = new_state["theme_constants"][constant_name]
+		var old_constant: Dictionary = old_state["theme_constants"][constant_name]
+		undo_redo.add_do_method(self, "_restore_theme_override", control, "constant", constant_name, new_constant["had"], new_constant["value"])
+		undo_redo.add_undo_method(self, "_restore_theme_override", control, "constant", constant_name, old_constant["had"], old_constant["value"])
+	undo_redo.commit_action()
 
 
 func _get_theme_info(params: Dictionary) -> Dictionary:

--- a/addons/godot_mcp/commands/tilemap_commands.gd
+++ b/addons/godot_mcp/commands/tilemap_commands.gd
@@ -37,7 +37,15 @@ func _tilemap_set_cell(params: Dictionary) -> Dictionary:
 	var atlas_y: int = int(params.get("atlas_y", 0))
 	var alternative: int = int(params.get("alternative", 0))
 
-	tilemap.set_cell(Vector2i(x, y), source_id, Vector2i(atlas_x, atlas_y), alternative)
+	var coords := Vector2i(x, y)
+	var old_cells := [_capture_cell(tilemap, coords)]
+	var new_cells := [_make_cell(coords, source_id, Vector2i(atlas_x, atlas_y), alternative)]
+
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Set TileMap cell")
+	undo_redo.add_do_method(self, "_apply_cells", tilemap, new_cells)
+	undo_redo.add_undo_method(self, "_apply_cells", tilemap, old_cells)
+	undo_redo.commit_action()
 
 	return success({"x": x, "y": y, "source_id": source_id, "atlas_coords": [atlas_x, atlas_y]})
 
@@ -62,10 +70,20 @@ func _tilemap_fill_rect(params: Dictionary) -> Dictionary:
 	var alternative: int = int(params.get("alternative", 0))
 
 	var count := 0
+	var old_cells: Array = []
+	var new_cells: Array = []
 	for cx in range(mini(x1, x2), maxi(x1, x2) + 1):
 		for cy in range(mini(y1, y2), maxi(y1, y2) + 1):
-			tilemap.set_cell(Vector2i(cx, cy), source_id, Vector2i(atlas_x, atlas_y), alternative)
+			var coords := Vector2i(cx, cy)
+			old_cells.append(_capture_cell(tilemap, coords))
+			new_cells.append(_make_cell(coords, source_id, Vector2i(atlas_x, atlas_y), alternative))
 			count += 1
+
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Fill TileMap rect")
+	undo_redo.add_do_method(self, "_apply_cells", tilemap, new_cells)
+	undo_redo.add_undo_method(self, "_apply_cells", tilemap, old_cells)
+	undo_redo.commit_action()
 
 	return success({"filled": count, "rect": [x1, y1, x2, y2]})
 
@@ -107,8 +125,39 @@ func _tilemap_clear(params: Dictionary) -> Dictionary:
 	if tilemap == null:
 		return error_not_found("TileMapLayer at '%s'" % node_path)
 
-	tilemap.clear()
+	var old_cells: Array = []
+	for coords: Vector2i in tilemap.get_used_cells():
+		old_cells.append(_capture_cell(tilemap, coords))
+
+	var undo_redo := get_undo_redo()
+	undo_redo.create_action("MCP: Clear TileMap")
+	undo_redo.add_do_method(tilemap, "clear")
+	undo_redo.add_undo_method(self, "_apply_cells", tilemap, old_cells)
+	undo_redo.commit_action()
 	return success({"cleared": true})
+
+
+func _make_cell(coords: Vector2i, source_id: int, atlas_coords: Vector2i, alternative: int) -> Dictionary:
+	return {
+		"coords": coords,
+		"source_id": source_id,
+		"atlas_coords": atlas_coords,
+		"alternative": alternative,
+	}
+
+
+func _capture_cell(tilemap: TileMapLayer, coords: Vector2i) -> Dictionary:
+	return _make_cell(
+		coords,
+		tilemap.get_cell_source_id(coords),
+		tilemap.get_cell_atlas_coords(coords),
+		tilemap.get_cell_alternative_tile(coords)
+	)
+
+
+func _apply_cells(tilemap: TileMapLayer, cells: Array) -> void:
+	for cell: Dictionary in cells:
+		tilemap.set_cell(cell["coords"], cell["source_id"], cell["atlas_coords"], cell["alternative"])
 
 
 func _tilemap_get_info(params: Dictionary) -> Dictionary:

--- a/addons/godot_mcp/commands/tilemap_commands.gd
+++ b/addons/godot_mcp/commands/tilemap_commands.gd
@@ -43,8 +43,8 @@ func _tilemap_set_cell(params: Dictionary) -> Dictionary:
 
 	var undo_redo := get_undo_redo()
 	undo_redo.create_action("MCP: Set TileMap cell")
-	undo_redo.add_do_method(self, "_apply_cells", tilemap, new_cells)
-	undo_redo.add_undo_method(self, "_apply_cells", tilemap, old_cells)
+	_add_do_set_cells(undo_redo, tilemap, new_cells)
+	_add_undo_set_cells(undo_redo, tilemap, old_cells)
 	undo_redo.commit_action()
 
 	return success({"x": x, "y": y, "source_id": source_id, "atlas_coords": [atlas_x, atlas_y]})
@@ -81,8 +81,8 @@ func _tilemap_fill_rect(params: Dictionary) -> Dictionary:
 
 	var undo_redo := get_undo_redo()
 	undo_redo.create_action("MCP: Fill TileMap rect")
-	undo_redo.add_do_method(self, "_apply_cells", tilemap, new_cells)
-	undo_redo.add_undo_method(self, "_apply_cells", tilemap, old_cells)
+	_add_do_set_cells(undo_redo, tilemap, new_cells)
+	_add_undo_set_cells(undo_redo, tilemap, old_cells)
 	undo_redo.commit_action()
 
 	return success({"filled": count, "rect": [x1, y1, x2, y2]})
@@ -132,7 +132,7 @@ func _tilemap_clear(params: Dictionary) -> Dictionary:
 	var undo_redo := get_undo_redo()
 	undo_redo.create_action("MCP: Clear TileMap")
 	undo_redo.add_do_method(tilemap, "clear")
-	undo_redo.add_undo_method(self, "_apply_cells", tilemap, old_cells)
+	_add_undo_set_cells(undo_redo, tilemap, old_cells)
 	undo_redo.commit_action()
 	return success({"cleared": true})
 
@@ -155,9 +155,14 @@ func _capture_cell(tilemap: TileMapLayer, coords: Vector2i) -> Dictionary:
 	)
 
 
-func _apply_cells(tilemap: TileMapLayer, cells: Array) -> void:
+func _add_do_set_cells(undo_redo: EditorUndoRedoManager, tilemap: TileMapLayer, cells: Array) -> void:
 	for cell: Dictionary in cells:
-		tilemap.set_cell(cell["coords"], cell["source_id"], cell["atlas_coords"], cell["alternative"])
+		undo_redo.add_do_method(tilemap, "set_cell", cell["coords"], cell["source_id"], cell["atlas_coords"], cell["alternative"])
+
+
+func _add_undo_set_cells(undo_redo: EditorUndoRedoManager, tilemap: TileMapLayer, cells: Array) -> void:
+	for cell: Dictionary in cells:
+		undo_redo.add_undo_method(tilemap, "set_cell", cell["coords"], cell["source_id"], cell["atlas_coords"], cell["alternative"])
 
 
 func _tilemap_get_info(params: Dictionary) -> Dictionary:


### PR DESCRIPTION
## Summary

- block offline scene saves when the target scene is open in the Godot editor
- save the active editor scene through `EditorInterface`
- route live scene mutations through `EditorUndoRedoManager`
- guard open script/shader writes unless explicitly forced
- make cross-scene property edits safer by default
- fix compatibility-test regressions for closed-scene forced writes, open shader edits, and script line-range edits

## Validation

- tested with the unmodified v1.13.2 server
- verified the original external-change warning no longer reproduces
- compatibility tests reported the expected behavior for active scene save, open scene offline-save blocking, inactive-open-scene protection, dry-run defaults, script guards, CLI force forwarding, undo/redo integration, and runtime smoke checks
- fixed follow-up failures reported by compatibility testing:
  - `cross_scene_set_property` closed-scene forced write returned early on an empty guard result
  - `edit_shader` did not detect cached/open shader resources and used invalid `Shader.reload_from_file()`
  - `edit_script` did not implement the CLI-advertised `start_line`/`end_line` path
- ran Godot `--headless --check-only --script` against all changed addon command scripts
- ran `git diff --check`

## Big changes

The change touches many addon command files because the bug was not isolated to a single save_scene implementation. The root problem was a broader unsafe editing pattern: MCP commands could mutate editor-owned resources or write files on disk while Godot still had those scenes, scripts, or resources open in memory.

Godot tracks open scenes, dirty state, undo/redo, and script editor buffers internally. If an MCP command bypasses that editor state by directly calling ResourceSaver.save(...), FileAccess, node.set(...), add_child(...), animation mutations, TileMap edits, or similar low-level operations, Godot can see the result as an external modification or fail to register the change as a normal editor action.

That is why the fix had to cover several categories of commands:

- shared safety helpers in base_command.gd
- scene save/create paths in scene_commands.gd
- broad cross-scene write behavior in batch_commands.gd
- script and shader file writes in script_commands.gd and shader_commands.gd
- generic resource/theme save paths that could indirectly touch scene files
- live scene mutation commands such as node, animation, animation tree, audio, navigation, particle, theme, and TileMap operations

The animation-related files were changed for the same reason: they modify resources that belong to the currently open editor scene. Adding animation tracks, inserting keys, editing animation tree nodes, or changing particle and navigation resources can all affect the live scene state. Those operations need to go through EditorUndoRedoManager or explicitly mark the scene unsaved so Godot treats them as editor-aware changes instead of silent background mutations.

In short, this PR is larger because it fixes the unsafe access pattern at the command-layer boundary, not just one visible symptom. The original external-change dialog was one reproduced failure mode, but the same design issue existed in multiple commands that either saved resources offline or mutated the active scene outside Godot's editor undo/dirty-state system.

## AI disclosure

Most of this change was AI-assisted in GitHub Copilot, using the model setting `Gpt-5.5 Xhigh`. The changes were reviewed and tested locally before submission.

## Final validation

- Final retest passed on Godot 4.6.2-stable/Linux: Tasks 1-30 passed with no failed or partial tasks.
- Task 31 PR file scope was not evaluable in the external test project because it was not a Git repository.
- Strict diagnostics and Godot parser checks passed for all 14 addon command files.
- Active scene saves use EditorInterface; offline overwrites of open scenes are blocked.
- Cross-scene safety passed: dry-run default, force required, inactive open scenes skipped/protected, closed scenes can be forced offline-saved.
- Open script/shader guards passed; forced script line-range edits passed; shader forced refresh and create guard passed after the cache takeover fix.
- Undo/redo passed for node, property, animation, animation tree, theme, and TileMap cell edits.
- Resource guard, navigation bake/save, particles, audio, save_scene_as, inactive open scene block, original regression coverage, and runtime smoke test passed.
- Latest PR head commit after branch update: fe9b278f4d0e6c43686e61b8db7742ca4e2c2c0a.

## Follow-up safety hardening

A follow-up retest found one more MCP-only route that could still trigger Godot external-change dialogs: `execute_editor_script` can run arbitrary editor GDScript, including direct file/resource write APIs, and `edit_resource` could save an open scene resource without the same guard used by the other scene/resource creation paths.

Additional commit `bfddd59` adds two addon-only safeguards:

- `edit_resource` now calls `guard_offline_scene_save(path)` before loading and saving resources, so open `.tscn`/`.scn` files are rejected consistently.
- `execute_editor_script` now rejects direct file/resource write APIs by default, including `ResourceSaver.save`, `ProjectSettings.save`, `ConfigFile.save`, `FileAccess.open(... WRITE ...)`, and mutating `DirAccess` operations. An explicit `allow_unsafe_editor_io=true` escape hatch remains for deliberate unsafe editor scripts when the caller knows no open editor-owned resource can be overwritten.

Local validation after this follow-up passed: VS Code diagnostics for the two touched files, Godot `--check-only` for both files, `git diff --check`, and a full parser check over the current addon command diff.

## Script command path safety

A further MCP-only test found that `edit_script` could be pointed at a closed `.tscn` file. Because script editing writes through `FileAccess.WRITE` and then refreshes Godot's resource filesystem, using it on scene files can still make Godot report that files were changed outside the editor.

Additional commit `6d8d650` closes that route by restricting script commands to actual script files:

- `create_script`, `edit_script`, and `validate_script` now accept only `.gd` and `.cs` paths.
- Scene files such as `.tscn` and `.scn` are rejected before any file I/O, even when `force=true` is provided.
- The error message directs callers to use scene commands for scenes and shader commands for shader resources instead of treating those resources as plain scripts.

Local validation for this follow-up passed: VS Code diagnostics for `script_commands.gd`, Godot `--check-only` for that file, and `git diff --check`.
