### PR TITLE
Add editor selection tools for scene node workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Godot MCP Pro
 
-Premium MCP (Model Context Protocol) server for AI-powered Godot game development. Connects AI assistants like Claude directly to your Godot editor with **172 powerful tools**.
+Premium MCP (Model Context Protocol) server for AI-powered Godot game development. Connects AI assistants like Claude directly to your Godot editor with **175 powerful tools**.
 
 ## Architecture
 
@@ -63,7 +63,7 @@ Godot MCP Pro offers four modes to fit any client's tool limit:
 
 | Mode | Tools | Best For |
 |------|-------|----------|
-| **Full** (default) | 172 | Claude Code, Cline, VS Code Copilot, Cursor |
+| **Full** (default) | 175 | Claude Code, Cline, VS Code Copilot, Cursor |
 | **3D** (`--3d`) | 100 | Antigravity and other 100-tool-limit clients needing 3D |
 | **Lite** (`--lite`) | 81 | Windsurf, JetBrains Junie, Gemini CLI |
 | **Minimal** (`--minimal`) | 35 | OpenCode, local LLMs with small context |
@@ -133,7 +133,7 @@ The CLI connects directly to the Godot editor plugin via WebSocket. It requires:
 
 Open your Godot project with the plugin enabled, then use Claude Code to interact with the editor.
 
-## All 172 Tools
+## All 175 Tools
 
 ### Project Tools (7)
 | Tool | Description |
@@ -159,7 +159,7 @@ Open your Godot project with the plugin enabled, then use Claude Code to interac
 | `stop_scene` | Stop running scene |
 | `save_scene` | Save current scene to disk |
 
-### Node Tools (14)
+### Node Tools (17)
 | Tool | Description |
 |------|-------------|
 | `add_node` | Add node with type and properties |
@@ -176,6 +176,9 @@ Open your Godot project with the plugin enabled, then use Claude Code to interac
 | `get_node_groups` | Get groups a node belongs to |
 | `set_node_groups` | Set node group membership |
 | `find_nodes_in_group` | Find all nodes in a group |
+| `get_editor_selection` | Get currently selected scene nodes |
+| `select_nodes` | Select, focus, and inspect scene nodes |
+| `clear_editor_selection` | Clear the editor scene selection |
 
 ### Script Tools (8)
 | Tool | Description |
@@ -439,7 +442,7 @@ Open your Godot project with the plugin enabled, then use Claude Code to interac
 | Material | 0 | 0 | 0 | 2 | 0 | 0 | 0 |
 | Other | 0 | 0 | 9 | 5 | 5 | 2 | 1 |
 | Android Deploy | **3** | 0 | 0 | 0 | 0 | 0 | 0 |
-| **Total** | **172** | ~30 | **32** | **39** | **13** | **19** | **10** |
+| **Total** | **175** | ~30 | **32** | **39** | **13** | **19** | **10** |
 
 ### Feature Matrix
 

--- a/addons/godot_mcp/commands/node_commands.gd
+++ b/addons/godot_mcp/commands/node_commands.gd
@@ -21,6 +21,9 @@ func get_commands() -> Dictionary:
 		"get_node_groups": _get_node_groups,
 		"set_node_groups": _set_node_groups,
 		"find_nodes_in_group": _find_nodes_in_group,
+		"get_editor_selection": _get_editor_selection,
+		"select_nodes": _select_nodes,
+		"clear_editor_selection": _clear_editor_selection,
 	}
 
 
@@ -315,6 +318,119 @@ func _get_node_properties(params: Dictionary) -> Dictionary:
 		"type": node.get_class(),
 		"properties": props,
 	})
+
+
+func _get_editor_selection(params: Dictionary) -> Dictionary:
+	var root := get_edited_root()
+	if root == null:
+		return error_no_scene()
+
+	var selection := EditorInterface.get_selection()
+	var include_top_only: bool = optional_bool(params, "top_only", false)
+	var selected_nodes: Array = selection.get_top_selected_nodes() if include_top_only else selection.get_selected_nodes()
+
+	return success({
+		"nodes": _serialize_selection_nodes(root, selected_nodes),
+		"count": selected_nodes.size(),
+		"top_only": include_top_only,
+	})
+
+
+func _select_nodes(params: Dictionary) -> Dictionary:
+	var root := get_edited_root()
+	if root == null:
+		return error_no_scene()
+
+	var node_paths_result := _get_selection_node_paths(params)
+	if node_paths_result[1] != null:
+		return node_paths_result[1]
+	var node_paths: Array = node_paths_result[0]
+
+	var mode: String = optional_string(params, "mode", "replace")
+	if mode != "replace" and mode != "add" and mode != "remove":
+		return error_invalid_params("mode must be one of: replace, add, remove")
+
+	var inspect: bool = optional_bool(params, "inspect", true)
+	var focus: bool = optional_bool(params, "focus", inspect)
+	var inspector_only: bool = optional_bool(params, "inspector_only", false)
+	var for_property: String = optional_string(params, "for_property", "")
+
+	var resolved_nodes: Array[Node] = []
+	for node_path_variant: Variant in node_paths:
+		var node_path := str(node_path_variant)
+		if node_path.is_empty():
+			return error_invalid_params("node_paths cannot contain empty values")
+		var node := find_node_by_path(node_path)
+		if node == null:
+			return error_not_found("Node '%s'" % node_path, "Use get_scene_tree to see available nodes")
+		resolved_nodes.append(node)
+
+	var selection := EditorInterface.get_selection()
+	if mode == "replace":
+		selection.clear()
+
+	for node: Node in resolved_nodes:
+		if mode == "remove":
+			selection.remove_node(node)
+		else:
+			selection.add_node(node)
+
+	if mode != "remove" and not resolved_nodes.is_empty():
+		var edited_node: Node = resolved_nodes[resolved_nodes.size() - 1]
+		if focus:
+			EditorInterface.edit_node(edited_node)
+		if inspect:
+			EditorInterface.inspect_object(edited_node, for_property, inspector_only)
+
+	var selected_nodes: Array = selection.get_selected_nodes()
+	return success({
+		"mode": mode,
+		"selected": _serialize_selection_nodes(root, selected_nodes),
+		"count": selected_nodes.size(),
+	})
+
+
+func _clear_editor_selection(_params: Dictionary) -> Dictionary:
+	var root := get_edited_root()
+	if root == null:
+		return error_no_scene()
+
+	var selection := EditorInterface.get_selection()
+	var before_count := selection.get_selected_nodes().size()
+	selection.clear()
+
+	return success({
+		"cleared": before_count,
+		"selected": [],
+		"count": 0,
+	})
+
+
+func _get_selection_node_paths(params: Dictionary) -> Array:
+	if params.has("node_paths"):
+		if not params["node_paths"] is Array:
+			return [[], error_invalid_params("node_paths must be an array of node paths")]
+		return [params["node_paths"], null]
+
+	var result := require_string(params, "node_path")
+	if result[1] != null:
+		return [[], result[1]]
+	return [[result[0]], null]
+
+
+func _serialize_selection_nodes(root: Node, nodes: Array) -> Array:
+	var serialized: Array = []
+	for node: Node in nodes:
+		if node == null:
+			continue
+		if node != root and not root.is_ancestor_of(node):
+			continue
+		serialized.append({
+			"name": node.name,
+			"path": str(root.get_path_to(node)) if node != root else ".",
+			"type": node.get_class(),
+		})
+	return serialized
 
 
 func _add_resource(params: Dictionary) -> Dictionary:


### PR DESCRIPTION
## Summary
This PR adds editor selection tools to Godot MCP Pro so MCP clients can read, modify, and clear the current SceneTree selection through Godot's official editor APIs.

The main goal is to make editor-driven workflows feel closer to how a human actually works in the Godot editor: after creating, duplicating, moving, or locating nodes, an MCP client can now also put the editor into the expected selection state and optionally focus the Inspector on the affected node or property.

## Why this belongs in Godot MCP Pro
Current Godot already exposes a stable, official selection API for editor tooling:

- `EditorInterface.get_selection()`
- `EditorSelection.add_node(node)`
- `EditorSelection.remove_node(node)`
- `EditorSelection.clear()`
- `EditorSelection.get_selected_nodes()`
- `EditorSelection.get_top_selected_nodes()`
- `EditorInterface.edit_node(node)`
- `EditorInterface.inspect_object(object, for_property, inspector_only)`

Before this change, Godot MCP Pro already had tools for creating, deleting, moving, inspecting properties, and managing groups/signals, but it still had a gap in editor-state control: MCP clients could know which node they had touched, but they could not update the actual editor selection to match that action.

That limitation matters in practice because many Godot editor workflows are selection-driven. Without selection tools, MCP interactions stay heavily data-oriented, but are less aligned with what users expect to see in the Scene dock and Inspector immediately after an action.

## New MCP commands
### 1. `get_editor_selection`
Reads the current editor selection from the active scene.

Parameters:
- `top_only` (optional, default: `false`)

Behavior:
- Uses `EditorSelection.get_selected_nodes()` when `top_only = false`
- Uses `EditorSelection.get_top_selected_nodes()` when `top_only = true`

Return value:
- `nodes`: array of selected nodes, each with `name`, `path`, and `type`
- `count`: number of returned nodes
- `top_only`: the applied filter mode

### 2. `select_nodes`
Updates the current editor selection for one or more nodes in the active scene.

Parameters:
- `node_path` for a single node
- `node_paths` for multiple nodes
- `mode` (optional, default: `replace`) with supported values:
  - `replace`
  - `add`
  - `remove`
- `inspect` (optional, default: `true`)
- `focus` (optional, default follows `inspect`)
- `for_property` (optional)
- `inspector_only` (optional, default: `false`)

Behavior:
- `replace` clears the existing selection first, then adds the requested nodes
- `add` appends nodes to the current selection
- `remove` removes nodes from the current selection
- When requested, the tool also calls `inspect_object()` and `edit_node()` for the last selected node so the editor UI follows the selection change

Validation and error handling:
- Rejects invalid modes with: `mode must be one of: replace, add, remove`
- Rejects empty entries inside `node_paths`
- Returns the existing structured `Node '<path>' not found` error for missing nodes, including the `get_scene_tree` suggestion

### 3. `clear_editor_selection`
Clears the current editor selection.

Return value:
- `cleared`: number of nodes that were selected before clearing
- `selected`: empty array
- `count`: always `0`

## Implementation details
### Command registration
The new commands are added to the node command set in:
- `addons/godot_mcp/commands/node_commands.gd`

This keeps the selection workflow close to the rest of the scene/node editor operations instead of creating a disconnected editor-only command surface.

### Internal helpers
Two internal helpers were added to keep the behavior predictable and the API shape stable:

- `_get_selection_node_paths(params)`
  - Normalizes `node_path` and `node_paths` into a single path array
  - Centralizes parameter handling for single- and multi-node selection operations

- `_serialize_selection_nodes(root, nodes)`
  - Filters out nodes that do not belong to the active scene root
  - Returns stable relative scene paths together with `name` and `type`

### Editor integration behavior
The implementation deliberately uses Godot's public editor API rather than depending on private dock internals.

This is important because:
- it aligns the MCP tool surface with documented Godot behavior,
- it reduces maintenance risk across editor changes,
- and it keeps the feature portable across normal editor usage instead of binding it to a specific Scene dock implementation.

## Documentation updates
The README was updated so the public tool inventory stays accurate:

- total tool count updated from **172** to **175**
- node tool count updated from **14** to **17**
- documentation entries added for:
  - `get_editor_selection`
  - `select_nodes`
  - `clear_editor_selection`

## Testing
I tested this change against the real Godot MCP command flow, not only through static inspection.

### 1. Script validation
Validated:
- `res://addons/godot_mcp/commands/node_commands.gd`

Result:
- `valid = true`
- message: `Script compiles successfully`

### 2. Editor error check
Ran `get_editor_errors` after the change.

Result:
- `count = 0`
- `errors = []`

### 3. Real JSON-RPC / WebSocket integration test in the test game
A local JSON-RPC/WebSocket test harness was used against the running Godot editor and the connected Godot MCP plugin.

The test flow covered:
- command re-registration through `execute_editor_script`
- `create_scene`
- `open_scene`
- `add_node`
- `select_nodes`
- `get_editor_selection`
- `clear_editor_selection`
- final `validate_script` and `get_editor_errors`
- cleanup through scene close and scene deletion

Concrete verified cases:
- `select_nodes` with `mode = replace` on `Parent`
  - result count: `1`
- `select_nodes` with `mode = add` for `Parent/Child` and `Sibling`
  - result count: `3`
- `get_editor_selection` without `top_only`
  - returned all 3 selected nodes
- `get_editor_selection` with `top_only = true`
  - returned only `Parent` and `Sibling`
  - correctly excluded `Parent/Child` because its parent was already selected
- `select_nodes` with `mode = remove`
  - selection updated correctly
- invalid mode error path
  - returned: `mode must be one of: replace, add, remove`
- missing node error path
  - returned: `Node 'DoesNotExist' not found`
- `clear_editor_selection`
  - returned `cleared = 2`, then selection count `0`
- final validation remained clean:
  - `valid = true`
  - `get_editor_errors` reported `0` errors

Final integration result:
- `PASS selection tools retest`

## Notes
This PR is intentionally separate from the earlier TileMap compatibility work so the new editor-selection functionality can be reviewed independently on its own merits.

## AI Assistance Disclosure
This PR was substantially developed with assistance from GitHub Copilot GPT 5.5. The implementation was still validated locally through the Godot MCP Pro script, editor, and WebSocket integration checks described above.
